### PR TITLE
Expose the Galaxy report webapp on port 9003 via nginx.

### DIFF
--- a/tasks/galaxy_root.yml
+++ b/tasks/galaxy_root.yml
@@ -9,7 +9,7 @@
   sudo: True
   sudo_user: "{{ galaxy_user_name }}"
 
-- name: "Install watchdog for galaxy"
+- name: "Install uwsgi for galaxy"
   shell: ". {{ galaxy_venv_dir }}/bin/activate && pip install uwsgi"
   sudo: True
   sudo_user: "{{ galaxy_user_name }}"

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -27,6 +27,36 @@ http {
     uwsgi_read_timeout 300;
 
     server {
+        # Galaxy report app
+        listen 9003;
+        server_name localhost;
+
+        location / {
+            proxy_pass http://127.0.0.1:9001;
+        }
+
+        # serve static content
+        location /static {
+            alias {{ galaxy_root }}/static;
+            gzip on;
+            gzip_types text/plain text/xml text/javascript text/css application/x-javascript;
+            expires 24h;
+        }
+        location /static/style {
+            alias {{ galaxy_root }}/static/style/blue;
+            gzip on;
+            gzip_types text/plain text/xml text/javascript text/css application/x-javascript;
+            expires 24h;
+        }
+        location /static/scripts {
+            alias {{ galaxy_root }}/static/scripts/packed;
+            gzip on;
+            gzip_types text/plain text/javascript application/x-javascript;
+            expires 24h;
+        }
+    }
+
+    server {
         listen 80 default_server;
         server_name  localhost;
 


### PR DESCRIPTION

* use nginx proxy
* serve static content