### PR TITLE
Add new nginx location so we can set welcome_url to /etc/galaxy/

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -111,6 +111,15 @@ http {
             alias /;
         }
 
+        # this is needed if 'welcome_url' is set to /etc/galaxy
+        location /root/welcome {
+            alias /etc/galaxy;
+            index welcome.html;
+            gzip on;
+            gzip_types text/plain text/xml text/javascript text/css application/x-javascript;
+            expires 24h;
+        }
+
         location ~ ^/plugins/visualizations/ipython/static/(?<static_file>.*?)$ {
             alias {{ galaxy_root }}/config/plugins/interactive_environments/ipython/static/$static_file;
         }


### PR DESCRIPTION
This is needed for https://github.com/bgruening/docker-galaxy-stable/issues/31 and potential debian packages.