### PR TITLE
nginx_proxy_reports_port is not needed anymore. 

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,7 +54,6 @@ codebox_port: 8991
 # Configure proxy to planemo-machine-web.
 nginx_serve_planemo_machine_web: false
 nginx_proxy_reports: true
-nginx_proxy_reports_port: "9003"
 
 galaxy_job_metrics_core: true
 galaxy_job_metrics_env: false

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -48,7 +48,7 @@ http {
 
             auth_basic $auth;
             auth_basic_user_file htpasswd;
-            proxy_pass http://127.0.0.1:{{ nginx_proxy_reports_port }}/;
+            proxy_pass http://127.0.0.1:{{ galaxy_reports_port }}/;
         }
         # serve static content for report app
         location /reports/static {


### PR DESCRIPTION
We can simply proxy to `galaxy_reports_port`. This will change the default port of reports from `9003` back to `9001`.