### PR TITLE
Remove obsolete --plugin python from supervisor template, and enforce…

### DIFF
--- a/tasks/supervisor.yml
+++ b/tasks/supervisor.yml
@@ -10,11 +10,20 @@
 - name: Create Galaxy configuration file
   template: src=supervisor.conf.j2 dest={{ supervisor_conf_path }}
 
+- name: Stop services before removing them.
+  service: name={{ item }} state=stopped
+  with_items:
+  - nginx
+  - uwsgi
+  - proftpd
+  - munge
+  - slurm-llnl
+
 - name: Disable init scripts for stuff managed by supervisor.
   command: update-rc.d -f {{ item }} remove || true
   with_items:
   - nginx
   - uwsgi
-  - proftp
+  - proftpd
   - munge
   - slurm-llnl

--- a/templates/supervisor.conf.j2
+++ b/templates/supervisor.conf.j2
@@ -68,7 +68,7 @@ priority        = 200
 
 [program:galaxy_web]
 {% if galaxy_uwsgi %}
-command         = {{ galaxy_venv_dir }}/bin/uwsgi --plugin python --ini-paste {{ galaxy_config_file }}
+command         = {{ galaxy_venv_dir }}/bin/uwsgi --ini-paste {{ galaxy_config_file }}
 directory       = {{ galaxy_root }}
 umask           = 022
 autostart       = true

--- a/templates/supervisor.conf.j2
+++ b/templates/supervisor.conf.j2
@@ -49,7 +49,7 @@ priority        = 100
 {% if supervisor_manage_proftp %}
 [program:proftpd]
 command         = /usr/sbin/proftpd -n -c {{proftpd_conf_path}}
-autostart       = false
+autostart       = true
 autorestart     = true
 {% endif %}
 


### PR DESCRIPTION
… stopping of services before removal.

We are using this role on a VM and in the cloud.
This way we do not need to stop the services manually before launching them in supervisor.