### PR TITLE
dynamic uwsgi processes and threads

### DIFF
--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -70,7 +70,7 @@ fi
 # $NONUSE can be set to include proftp, reports or nodejs
 # if included we will _not_ start these services.
 function start_supervisor {
-    /usr/bin/supervisord
+    supervisord -c /etc/supervisor/supervisord.conf
     sleep 5
     {% if supervisor_manage_proftp %}
     if [[ $NONUSE != *"proftp"* ]]

--- a/templates/supervisor.conf.j2
+++ b/templates/supervisor.conf.j2
@@ -68,7 +68,7 @@ priority        = 200
 
 [program:galaxy_web]
 {% if galaxy_uwsgi %}
-command         = {{ galaxy_venv_dir }}/bin/uwsgi --plugin python --ini-paste {{ galaxy_config_file }}
+command         = {{ galaxy_venv_dir }}/bin/uwsgi --plugin python --ini-paste {{ galaxy_config_file }} --logdate --master --processes %(ENV_UWSGI_PROCESSES)s --threads %(ENV_UWSGI_THREADS)s --logto %(ENV_GALAXY_HOME)s/uwsgi.log --socket 127.0.0.1:4001 --pythonpath lib --stats 127.0.0.1:9191
 directory       = {{ galaxy_root }}
 umask           = 022
 autostart       = true


### PR DESCRIPTION
This will help in solving https://github.com/bgruening/docker-galaxy-stable/issues/40.
@jmchilton please note that you need to set `UWSGI_PROCESSES=2`  and `UWSGI_THREADS=4` to use this role.