### PR TITLE
plugin python is built into core uwsgi if installed via pip.

### DIFF
--- a/templates/supervisor.conf.j2
+++ b/templates/supervisor.conf.j2
@@ -68,7 +68,7 @@ priority        = 200
 
 [program:galaxy_web]
 {% if galaxy_uwsgi %}
-command         = {{ galaxy_venv_dir }}/bin/uwsgi --plugin python --ini-paste {{ galaxy_config_file }} --logdate --master --processes %(ENV_UWSGI_PROCESSES)s --threads %(ENV_UWSGI_THREADS)s --logto %(ENV_GALAXY_HOME)s/uwsgi.log --socket 127.0.0.1:4001 --pythonpath lib --stats 127.0.0.1:9191
+command         = {{ galaxy_venv_dir }}/bin/uwsgi --ini-paste {{ galaxy_config_file }} --logdate --master --processes %(ENV_UWSGI_PROCESSES)s --threads %(ENV_UWSGI_THREADS)s --logto %(ENV_GALAXY_HOME)s/uwsgi.log --socket 127.0.0.1:4001 --pythonpath lib --stats 127.0.0.1:9191
 directory       = {{ galaxy_root }}
 umask           = 022
 autostart       = true


### PR DESCRIPTION
[Distros should package uWSGI in a modular way, with each feature as a plugin. But when you install using language specific ways (pip, gem...) the relevant language is embedded, so you do not need to load the plugin] (http://stackoverflow.com/a/15941424)

I tested this with the stable branch of @bgruening docker-galaxy-stable, where this works fine.
(uwsgi is installed into the virtualenv environment using pip)
If we do have `--plugin python` in all of our current project, starting galaxy_web fails with
```
open("./python_plugin.so"): No such file or directory [core/utils.c line 3675]
!!! UNABLE to load uWSGI plugin: ./python_plugin.so: cannot open shared object file: No such file or directory !!!
``` 
This has also occured [here](https://github.com/bgruening/docker-galaxy-stable/issues/76)
It also supersedes PR #21 