### PR TITLE
Fix for expanduser - conda

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,6 +53,9 @@ galaxy_database_connection: "postgres://{{ galaxy_user_name }}@localhost:{{ gala
 galaxy_uwsgi: true
 uwsgi_port: 4001
 
+# Set to true to write thread/process number into supervisor config. If false, uses environmental variables.
+galaxy_uwsgi_static_conf: false
+
 # Set the following to true - to run paste processes for Galaxy
 # handlers (should not longer be needed).
 galaxy_paste_handlers: false

--- a/templates/supervisor.conf.j2
+++ b/templates/supervisor.conf.j2
@@ -79,7 +79,7 @@ autostart       = true
 autorestart     = true
 startsecs       = {{ supervisor_galaxy_startsecs }}
 user            = {{ galaxy_user_name }}
-environment     = PATH={{ galaxy_venv_dir }}:{{ galaxy_venv_dir }}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin,PYTHON_EGG_CACHE={{ galxy_egg_cache }},PYTHONPATH={{ galaxy_root }}/eggs/PasteDeploy-1.5.0-py2.7.egg
+environment     = HOME={{ galaxy_home_dir  }},PATH={{ galaxy_venv_dir }}:{{ galaxy_venv_dir }}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin,PYTHON_EGG_CACHE={{ galxy_egg_cache }},PYTHONPATH={{ galaxy_root }}/eggs/PasteDeploy-1.5.0-py2.7.egg
 numprocs        = 1
 stopsignal      = INT
 startretries    = {{ supervisor_galaxy_startretries }}
@@ -94,7 +94,7 @@ autostart       = true
 autorestart     = true
 startsecs       = {{ supervisor_galaxy_startsecs }}
 user            = {{ galaxy_user_name }}
-environment     = PYTHON_EGG_CACHE={{ galxy_egg_cache }}
+environment     = HOME={{ galaxy_home_dir  }},PYTHON_EGG_CACHE={{ galxy_egg_cache }}
 startretries    = {{ supervisor_galaxy_startretries }}
 # needed for bash wrapper
 stopasgroup     = true
@@ -114,7 +114,7 @@ autostart       = true
 autorestart     = true
 startsecs       = {{ supervisor_galaxy_startsecs }}
 user            = {{ galaxy_user_name }}
-environment     = PYTHON_EGG_CACHE={{ galxy_egg_cache }}
+environment     = HOME={{ galaxy_home_dir  }},PYTHON_EGG_CACHE={{ galxy_egg_cache }}
 startretries    = {{ supervisor_galaxy_startretries }}
 
 {% if supervisor_manage_reports %}
@@ -127,7 +127,7 @@ autostart       = false
 autorestart     = true
 startsecs       = {{ supervisor_galaxy_startsecs }}
 user            = {{ galaxy_user_name }}
-environment     = PYTHON_EGG_CACHE={{ galxy_egg_cache }}
+environment     = HOME={{ galaxy_home_dir  }},PYTHON_EGG_CACHE={{ galxy_egg_cache }}
 startretries    = {{ supervisor_galaxy_startretries }}
 {% endif %}
 
@@ -141,7 +141,7 @@ autostart       = true
 autorestart     = true
 startsecs       = {{ supervisor_galaxy_startsecs }}
 user            = {{ galaxy_user_name }}
-environment     = PYTHON_EGG_CACHE={{ galxy_egg_cache }}
+environment     = {{ galaxy_home_dir  }},PYTHON_EGG_CACHE={{ galxy_egg_cache }}
 startretries    = {{ supervisor_galaxy_startretries }}
 {% endif %}
 


### PR DESCRIPTION
The new conda dependency resolver will expand '~', which points to root (the user that starts supervisor).
Circumvent the problem by specifying HOME in the environmental variables.