### PR TITLE
venv fixes for galaxy-on-wheels and improvements for running outside of docker

### DIFF
--- a/tasks/supervisor.yml
+++ b/tasks/supervisor.yml
@@ -10,6 +10,9 @@
 - name: Create Galaxy configuration file
   template: src=supervisor.conf.j2 dest={{ supervisor_conf_path }}
 
+- name: Stop supervisor
+  service: name=supervisor state=stopped
+
 - name: Stop services before removing them.
   service: name={{ item }} state=stopped enabled=no
   with_items:
@@ -36,3 +39,6 @@
   with_items:
   - postgresql
   when: supervisor_manage_postgres
+
+- name: Start supervisor
+  service: name=supervisor state=started

--- a/tasks/supervisor.yml
+++ b/tasks/supervisor.yml
@@ -40,5 +40,7 @@
   - postgresql
   when: supervisor_manage_postgres
 
+# Do not start supervisor when building docker-galaxy-stable
 - name: Start supervisor
   service: name=supervisor state=started
+  when: galaxy_uwsgi_static_conf

--- a/templates/supervisor.conf.j2
+++ b/templates/supervisor.conf.j2
@@ -35,6 +35,13 @@ priority=300
 {% endif %}
 
 {% if supervisor_manage_postgres %}
+{% if ansible_virtualization_type != "docker" %}
+[program:pre_postgresql]
+user            = root
+startsecs       = 0
+command         = /bin/bash -c "install -d -m 2775 -o postgres -g postgres /var/run/postgresql"
+{% endif %}
+
 [program:postgresql]
 user            = postgres
 command         = /usr/lib/postgresql/{{ postgresql_version }}/bin/postmaster -D "{{supervisor_postgres_database_path}}"

--- a/templates/supervisor.conf.j2
+++ b/templates/supervisor.conf.j2
@@ -76,9 +76,9 @@ priority        = 200
 [program:galaxy_web]
 {% if galaxy_uwsgi %}
 {% if galaxy_uwsgi_static_conf %}
-command         = {{ galaxy_venv_dir }}/bin/uwsgi --ini-paste {{ galaxy_config_file }} --logdate --master --processes {{ galaxy_web_processes }} --threads {{ uwsgi_threads }} --logto {{ galaxy_log_dir }}/uwsgi.log --socket 127.0.0.1:4001 --pythonpath lib --stats 127.0.0.1:9191
+command         = {{ galaxy_venv_dir }}/bin/uwsgi --virtualenv {{ galaxy_venv_dir }} --ini-paste {{ galaxy_config_file }} --logdate --master --processes {{ galaxy_web_processes }} --threads {{ uwsgi_threads }} --logto {{ galaxy_log_dir }}/uwsgi.log --socket 127.0.0.1:4001 --pythonpath lib --stats 127.0.0.1:9191
 {% else %}
-command         = {{ galaxy_venv_dir }}/bin/uwsgi --ini-paste {{ galaxy_config_file }} --logdate --master --processes %(ENV_UWSGI_PROCESSES)s --threads %(ENV_UWSGI_THREADS)s --logto %(ENV_GALAXY_HOME)s/uwsgi.log --socket 127.0.0.1:4001 --pythonpath lib --stats 127.0.0.1:9191
+command         = {{ galaxy_venv_dir }}/bin/uwsgi --virtualenv {{ galaxy_venv_dir }} --ini-paste {{ galaxy_config_file }} --logdate --master --processes %(ENV_UWSGI_PROCESSES)s --threads %(ENV_UWSGI_THREADS)s --logto %(ENV_GALAXY_HOME)s/uwsgi.log --socket 127.0.0.1:4001 --pythonpath lib --stats 127.0.0.1:9191
 {% endif %}
 directory       = {{ galaxy_root }}
 umask           = 022
@@ -121,7 +121,7 @@ autostart       = true
 autorestart     = true
 startsecs       = {{ supervisor_galaxy_startsecs }}
 user            = {{ galaxy_user_name }}
-environment     = PYTHON_EGG_CACHE={{ galxy_egg_cache }}
+environment     = PYTHON_EGG_CACHE={{ galxy_egg_cache }},PYTHONHOME={{ galaxy_venv_dir }}
 startretries    = {{ supervisor_galaxy_startretries }}
 
 {% if supervisor_manage_reports %}


### PR DESCRIPTION
- 2d7774e stop supervisor during service management.

- 851f58c since the ENV variables are not available during `docker build` we don't start supervisor back up if we use ENV vars to control supervisor managed programs. [docker-galaxy-stable continues to work]

- 776ad83 on real machines (VM or bare metal), we need to create /var/run/postgresql with the proper permissions once after boot. This will run the install command once (`startsecs = 0`) after starting supervisor if we are not in docker. Same thing happens in init.d script supplied with ubuntu.

-  3b3a964 we still need PYTHONHOME for the handler, else handler jobs will fail while looking for sqlalchemy.orm.