### PR TITLE
Detect if proftp, posgresql or nginx was set to be controled by supervisor

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -99,6 +99,7 @@ proftpd_db_username: galaxy
 proftpd_db_password: galaxy
 proftpd_welcome: "Public Galaxy FTP"
 proftpd_files_dir: /export/galaxy-central/database/ftp
+supervisor_proftpd_autostart: true
 
 ## Supervisor Configuration.
 supervisor_conf_path: "/etc/supervisor/conf.d/galaxy.conf"

--- a/tasks/supervisor.yml
+++ b/tasks/supervisor.yml
@@ -10,11 +10,20 @@
 - name: Create Galaxy configuration file
   template: src=supervisor.conf.j2 dest={{ supervisor_conf_path }}
 
+- name: Stop services before removing them.
+  service: name={{ item }} state=stopped
+  with_items:
+  - nginx
+  - uwsgi
+  - proftpd
+  - munge
+  - slurm-llnl
+
 - name: Disable init scripts for stuff managed by supervisor.
   command: update-rc.d -f {{ item }} remove || true
   with_items:
   - nginx
   - uwsgi
-  - proftp
+  - proftpd
   - munge
   - slurm-llnl

--- a/tasks/supervisor.yml
+++ b/tasks/supervisor.yml
@@ -52,5 +52,3 @@
 
 - name: Start supervisor
   service: name=supervisor state=started
-
-  

--- a/tasks/supervisor.yml
+++ b/tasks/supervisor.yml
@@ -11,19 +11,49 @@
   template: src=supervisor.conf.j2 dest={{ supervisor_conf_path }}
 
 - name: Stop services before removing them.
-  service: name={{ item }} state=stopped
-  with_items:
-  - nginx
-  - uwsgi
-  - proftpd
-  - munge
-  - slurm-llnl
+  service: name=postgresql state=stopped
+  when: supervisor_manage_postgresql
 
 - name: Disable init scripts for stuff managed by supervisor.
-  command: update-rc.d -f {{ item }} remove || true
-  with_items:
-  - nginx
-  - uwsgi
-  - proftpd
-  - munge
-  - slurm-llnl
+  command: update-rc.d -f postgresql remove || true
+  when: supervisor_manage_postgresql
+
+- name: Stop services before removing them.
+  service: name=slurm-llnl state=stopped
+  when: supervisor_manage_slurm
+
+- name: Disable init scripts for stuff managed by supervisor.
+  command: update-rc.d -f slurm-llnl remove || true
+  when: supervisor_manage_slurm
+
+- name: Stop services before removing them.
+  service: name=munge state=stopped
+  when: supervisor_manage_munge
+
+- name: Disable init scripts for stuff managed by supervisor.
+  command: update-rc.d -f munge remove || true
+  when: supervisor_manage_munge
+
+- name: Stop services before removing them.
+  service: name=proftpd state=stopped
+  when: supervisor_manage_proftpd
+
+- name: Disable init scripts for stuff managed by supervisor.
+  command: update-rc.d -f proftpd remove || true
+  when: supervisor_manage_proftpd
+
+- name: Stop services before removing them.
+  service: name=uwsgi state=stopped
+  when: supervisor_manage_uwsgi
+
+- name: Disable init scripts for stuff managed by supervisor.
+  command: update-rc.d -f uwsgi remove || true
+  when: supervisor_manage_uwsgi
+
+- name: Stop services before removing them.
+  service: name=nginx state=stopped
+  when: supervisor_manage_nginx
+
+- name: Disable init scripts for stuff managed by supervisor.
+  command: update-rc.d -f nginx remove || true
+  when: supervisor_manage_nginx

--- a/tasks/supervisor.yml
+++ b/tasks/supervisor.yml
@@ -19,32 +19,32 @@
     - uwsgi
     - munge
 
-- name: Stop slurm service before removing it.
+- name: Stop and remove slurm.
   service: name={{ item }} state=stopped enabled=no
   with_items:
     - slurm-llnl
   when: supervisor_manage_slurm and ansible_distribution_version <= "15.04"
 
-- name: Stop slurm service before removing it.
+- name: Stop and remove slurm.
   service: name={{ item }} state=stopped enabled=no
   with_items:
     - slurmd
     - slurmctld
   when: supervisor_manage_slurm and ansible_distribution_version > "15.04"
 
-- name: Stop postgresql before removing it from services.
+- name: Stop and remove postgresql.
   service: name={{ item }} state=stopped enabled=no
   with_items:
     - postgresql
   when: supervisor_manage_postgres
 
-- name: Stop proftpd service before removing them.
+- name: Stop and remove proftpd.
   service: name={{ item }} state=stopped enabled=no
   with_items:
     - proftpd
   when: supervisor_manage_proftp
 
-- name: Stop nginx service before removing them.
+- name: Stop and remove nginx.
   service: name={{ item }} state=stopped enabled=no
   with_items:
     - nginx

--- a/tasks/supervisor.yml
+++ b/tasks/supervisor.yml
@@ -10,51 +10,47 @@
 - name: Create Galaxy configuration file
   template: src=supervisor.conf.j2 dest={{ supervisor_conf_path }}
 
+- name: Stop supervisor
+  service: name=supervisor state=stopped
+
 - name: Stop services before removing them.
-  service: name={{ item }} state=stopped
+  service: name={{ item }} state=stopped enabled=no
   with_items:
     - uwsgi
     - munge
 
-- name: Disable init scripts for stuff managed by supervisor.
-  service: name={{ item }} enabled=false
-#  command: update-rc.d -f {{ item }} remove || true
+- name: Stop slurm service before removing it.
+  service: name={{ item }} state=stopped enabled=no
   with_items:
-  - uwsgi
-  - munge
-
-- name: Stop postgresql before removing it from services.
-  service: name=postgresql state=stopped
-  when: supervisor_manage_postgres
-
-- name: Disable postgresql init script for stuff managed by supervisor.
-  service: name=postgresql enabled=false
-#  command: update-rc.d -f postgresql remove || true
-  when: supervisor_manage_postgres
+    - slurm-llnl
+  when: supervisor_manage_slurm and ansible_distribution_version <= "15.04"
 
 - name: Stop slurm service before removing it.
-  service: name=slurm-llnl state=stopped
-  when: supervisor_manage_slurm
+  service: name={{ item }} state=stopped enabled=no
+  with_items:
+    - slurmd
+    - slurmctld
+  when: supervisor_manage_slurm and ansible_distribution_version > "15.04"
 
-- name: Disable slurm init script for stuff managed by supervisor.
-  service: name=slurm-llnl enabled=false
-#  command: update-rc.d -f slurm-llnl remove || true
-  when: supervisor_manage_slurm
+- name: Stop postgresql before removing it from services.
+  service: name={{ item }} state=stopped enabled=no
+  with_items:
+    - postgresql
+  when: supervisor_manage_postgres
 
 - name: Stop proftpd service before removing them.
-  service: name=proftpd state=stopped
-  when: supervisor_manage_proftp
-
-- name: Disable proftpd init script for stuff managed by supervisor.
-  service: name=proftpd enabled=false
-#  command: update-rc.d -f proftpd remove || true
+  service: name={{ item }} state=stopped enabled=no
+  with_items:
+    - proftpd
   when: supervisor_manage_proftp
 
 - name: Stop nginx service before removing them.
-  service: name=nginx state=stopped
+  service: name={{ item }} state=stopped enabled=no
+  with_items:
+    - nginx
   when: supervisor_manage_nginx
 
-- name: Disable nginx init script for stuff managed by supervisor.
-  service: name=nginx enabled=false
-#  command: update-rc.d -f nginx remove || true
-  when: supervisor_manage_nginx
+- name: Start supervisor
+  service: name=supervisor state=started
+
+  

--- a/tasks/supervisor.yml
+++ b/tasks/supervisor.yml
@@ -11,49 +11,50 @@
   template: src=supervisor.conf.j2 dest={{ supervisor_conf_path }}
 
 - name: Stop services before removing them.
-  service: name=postgresql state=stopped
-  when: supervisor_manage_postgresql
+  service: name={{ item }} state=stopped
+  with_items:
+    - uwsgi
+    - munge
 
 - name: Disable init scripts for stuff managed by supervisor.
-  command: update-rc.d -f postgresql remove || true
-  when: supervisor_manage_postgresql
+  service: name={{ item }} enabled=false
+#  command: update-rc.d -f {{ item }} remove || true
+  with_items:
+  - uwsgi
+  - munge
 
-- name: Stop services before removing them.
+- name: Stop postgresql before removing it from services.
+  service: name=postgresql state=stopped
+  when: supervisor_manage_postgres
+
+- name: Disable postgresql init script for stuff managed by supervisor.
+  service: name=postgresql enabled=false
+#  command: update-rc.d -f postgresql remove || true
+  when: supervisor_manage_postgres
+
+- name: Stop slurm service before removing it.
   service: name=slurm-llnl state=stopped
   when: supervisor_manage_slurm
 
-- name: Disable init scripts for stuff managed by supervisor.
-  command: update-rc.d -f slurm-llnl remove || true
+- name: Disable slurm init script for stuff managed by supervisor.
+  service: name=slurm-llnl enabled=false
+#  command: update-rc.d -f slurm-llnl remove || true
   when: supervisor_manage_slurm
 
-- name: Stop services before removing them.
-  service: name=munge state=stopped
-  when: supervisor_manage_munge
-
-- name: Disable init scripts for stuff managed by supervisor.
-  command: update-rc.d -f munge remove || true
-  when: supervisor_manage_munge
-
-- name: Stop services before removing them.
+- name: Stop proftpd service before removing them.
   service: name=proftpd state=stopped
-  when: supervisor_manage_proftpd
+  when: supervisor_manage_proftp
 
-- name: Disable init scripts for stuff managed by supervisor.
-  command: update-rc.d -f proftpd remove || true
-  when: supervisor_manage_proftpd
+- name: Disable proftpd init script for stuff managed by supervisor.
+  service: name=proftpd enabled=false
+#  command: update-rc.d -f proftpd remove || true
+  when: supervisor_manage_proftp
 
-- name: Stop services before removing them.
-  service: name=uwsgi state=stopped
-  when: supervisor_manage_uwsgi
-
-- name: Disable init scripts for stuff managed by supervisor.
-  command: update-rc.d -f uwsgi remove || true
-  when: supervisor_manage_uwsgi
-
-- name: Stop services before removing them.
+- name: Stop nginx service before removing them.
   service: name=nginx state=stopped
   when: supervisor_manage_nginx
 
-- name: Disable init scripts for stuff managed by supervisor.
-  command: update-rc.d -f nginx remove || true
+- name: Disable nginx init script for stuff managed by supervisor.
+  service: name=nginx enabled=false
+#  command: update-rc.d -f nginx remove || true
   when: supervisor_manage_nginx

--- a/templates/supervisor.conf.j2
+++ b/templates/supervisor.conf.j2
@@ -56,7 +56,7 @@ priority        = 100
 {% if supervisor_manage_proftp %}
 [program:proftpd]
 command         = /usr/sbin/proftpd -n -c {{proftpd_conf_path}}
-autostart       = true
+autostart       = {{ supervisor_proftpd_autostart }}
 autorestart     = true
 {% endif %}
 

--- a/templates/supervisor.conf.j2
+++ b/templates/supervisor.conf.j2
@@ -68,7 +68,7 @@ priority        = 200
 
 [program:galaxy_web]
 {% if galaxy_uwsgi %}
-command         = {{ galaxy_venv_dir }}/bin/uwsgi --plugin python --ini-paste {{ galaxy_config_file }}
+command         = {{ galaxy_venv_dir }}/bin/uwsgi --ini-paste {{ galaxy_config_file }}
 directory       = {{ galaxy_root }}
 umask           = 022
 autostart       = true

--- a/templates/supervisor.conf.j2
+++ b/templates/supervisor.conf.j2
@@ -68,7 +68,7 @@ priority        = 200
 
 [program:galaxy_web]
 {% if galaxy_uwsgi %}
-command         = {{ galaxy_venv_dir }}/bin/uwsgi --ini-paste {{ galaxy_config_file }}
+command         = {{ galaxy_venv_dir }}/bin/uwsgi --plugin python --ini-paste {{ galaxy_config_file }}
 directory       = {{ galaxy_root }}
 umask           = 022
 autostart       = true

--- a/templates/supervisor.conf.j2
+++ b/templates/supervisor.conf.j2
@@ -49,7 +49,7 @@ priority        = 100
 {% if supervisor_manage_proftp %}
 [program:proftpd]
 command         = /usr/sbin/proftpd -n -c {{proftpd_conf_path}}
-autostart       = false
+autostart       = true
 autorestart     = true
 {% endif %}
 


### PR DESCRIPTION
If proftp, posgresql, slurm or nginx are not controlled by supervisor, the previous tasks/supervisor.yml with remove them from the auto-start status and possibly crash other services that depend on them.