### PR TITLE
Detect if proftp, posgresql, slurm or nginx were set to be controled by supervisor

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -129,7 +129,6 @@ supervisor_galaxy_startsecs: 20
 supervisor_galaxy_startretries: 15
 
 supervisor_ie_proxy_autostart: false
-supervisor_proftpd_autostart: false
 supervisor_reports_autostart: false
 
 supervisor_docker_autostart: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -128,3 +128,5 @@ supervisor_webserver: true
 supervisor_webserver_port: "0.0.0.0:9002"
 supervisor_webserver_username: null
 supervisor_webserver_password: changeme
+
+supervisor_proftpd_autostart: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -107,6 +107,7 @@ supervisor_slurm_config_dir: "/home/galaxy"
 supervisor_manage_postgres: true
 postgresql_version: 9.3
 supervisor_postgres_database_path: "/export/postgresql/{{ postgresql_version }}/main"
+supervisor_postgres_database_config: "/export/postgresql/{{ postgresql_version }}/main/postgresql.conf"
 supervisor_manage_proftp: true
 supervisor_manage_nginx: true
 supervisor_manage_reports: true

--- a/tasks/supervisor.yml
+++ b/tasks/supervisor.yml
@@ -16,29 +16,39 @@
 - name: Stop services before removing them.
   service: name={{ item }} state=stopped enabled=no
   with_items:
-  - nginx
-  - uwsgi
-  - proftpd
-  - munge
+    - uwsgi
+    - munge
 
-- name: Stop services before removing them.
+- name: Stop and remove slurm.
   service: name={{ item }} state=stopped enabled=no
   with_items:
-  - slurm-llnl
-  when: ansible_distribution_version <= "15.04"
+    - slurm-llnl
+  when: supervisor_manage_slurm and ansible_distribution_version <= "15.04"
 
-- name: Stop services before removing them.
+- name: Stop and remove slurm.
   service: name={{ item }} state=stopped enabled=no
   with_items:
-  - slurmd
-  - slurmctld
-  when: ansible_distribution_version > "15.04"
+    - slurmd
+    - slurmctld
+  when: supervisor_manage_slurm and ansible_distribution_version > "15.04"
 
-- name: Stop services before removing them.
+- name: Stop and remove postgresql.
   service: name={{ item }} state=stopped enabled=no
   with_items:
-  - postgresql
+    - postgresql
   when: supervisor_manage_postgres
+
+- name: Stop and remove proftpd.
+  service: name={{ item }} state=stopped enabled=no
+  with_items:
+    - proftpd
+  when: supervisor_manage_proftp
+
+- name: Stop and remove nginx.
+  service: name={{ item }} state=stopped enabled=no
+  with_items:
+    - nginx
+  when: supervisor_manage_nginx
 
 # Do not start supervisor when building docker-galaxy-stable
 - name: Start supervisor

--- a/templates/supervisor.conf.j2
+++ b/templates/supervisor.conf.j2
@@ -59,6 +59,7 @@ priority        = 100
 command         = bash -c " export MASQUERADE_ADDRESS={{ proftpd_masquerade_address }} && /usr/sbin/proftpd -n -c {{proftpd_conf_path}}"
 {% else %}
 command         = /usr/sbin/proftpd -n -c {{proftpd_conf_path}}
+{% endif %}
 autostart       = {{ supervisor_proftpd_autostart }}
 autorestart     = true
 stopasgroup     = true

--- a/templates/supervisor.conf.j2
+++ b/templates/supervisor.conf.j2
@@ -44,7 +44,8 @@ command         = /bin/bash -c "install -d -m 2775 -o postgres -g postgres /var/
 
 [program:postgresql]
 user            = postgres
-command         = /usr/lib/postgresql/{{ postgresql_version }}/bin/postmaster -D "{{supervisor_postgres_database_path}}"
+command         = /usr/lib/postgresql/{{ postgresql_version }}/bin/postmaster -D {{supervisor_postgres_database_path}} -c "config_file={{ supervisor_postgres_database_config }}"
+
 process_name    = %(program_name)s
 stopsignal      = INT
 autostart       = true

--- a/templates/supervisor.conf.j2
+++ b/templates/supervisor.conf.j2
@@ -56,7 +56,7 @@ priority        = 100
 {% if supervisor_manage_proftp %}
 [program:proftpd]
 command         = /usr/sbin/proftpd -n -c {{proftpd_conf_path}}
-autostart       = false
+autostart       = {{ supervisor_proftpd_autostart }}
 autorestart     = true
 {% endif %}
 


### PR DESCRIPTION
Changes:
   Detect if proftp, posgresql, slurm or nginx were set to be controled by supervisor and deal with the systems services accordingly. 
  The autostart of proftpd is now an option.
   