### PR TITLE
Detect if proftp, posgresql, slurm or nginx are controled by supervisor

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -115,6 +115,7 @@ supervisor_slurm_config_dir: "/home/galaxy"
 supervisor_manage_postgres: true
 postgresql_version: 9.3
 supervisor_postgres_database_path: "/export/postgresql/{{ postgresql_version }}/main"
+supervisor_postgres_database_config: "/export/postgresql/{{ postgresql_version }}/main/postgresql.conf"
 supervisor_manage_proftp: true
 supervisor_manage_nginx: true
 supervisor_manage_reports: true
@@ -128,7 +129,6 @@ supervisor_galaxy_startsecs: 20
 supervisor_galaxy_startretries: 15
 
 supervisor_ie_proxy_autostart: false
-supervisor_proftpd_autostart: false
 supervisor_reports_autostart: false
 
 supervisor_docker_autostart: false
@@ -138,3 +138,5 @@ supervisor_webserver: true
 supervisor_webserver_port: "0.0.0.0:9002"
 supervisor_webserver_username: null
 supervisor_webserver_password: changeme
+
+supervisor_proftpd_autostart: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -114,7 +114,8 @@ supervisor_manage_slurm: true
 supervisor_slurm_config_dir: "/home/galaxy"
 supervisor_manage_postgres: true
 postgresql_version: 9.3
-supervisor_postgres_options: "-D /export/postgresql/{{ postgresql_version }}/main"
+supervisor_postgres_database_path: "/export/postgresql/{{ postgresql_version }}/main"
+supervisor_postgres_options: "-D {{ supervisor_postgres_database_path }}"
 supervisor_manage_proftp: true
 supervisor_manage_nginx: true
 supervisor_manage_reports: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -114,8 +114,7 @@ supervisor_manage_slurm: true
 supervisor_slurm_config_dir: "/home/galaxy"
 supervisor_manage_postgres: true
 postgresql_version: 9.3
-supervisor_postgres_database_path: "/export/postgresql/{{ postgresql_version }}/main"
-supervisor_postgres_database_config: "/export/postgresql/{{ postgresql_version }}/main/postgresql.conf"
+supervisor_postgres_options: "-D /export/postgresql/{{ postgresql_version }}/main"
 supervisor_manage_proftp: true
 supervisor_manage_nginx: true
 supervisor_manage_reports: true
@@ -130,7 +129,7 @@ supervisor_galaxy_startretries: 15
 
 supervisor_ie_proxy_autostart: false
 supervisor_reports_autostart: false
-
+supervisor_proftpd_autostart: false
 supervisor_docker_autostart: false
 supervisor_docker_autorestart: true
 
@@ -138,5 +137,3 @@ supervisor_webserver: true
 supervisor_webserver_port: "0.0.0.0:9002"
 supervisor_webserver_username: null
 supervisor_webserver_password: changeme
-
-supervisor_proftpd_autostart: false

--- a/tasks/supervisor.yml
+++ b/tasks/supervisor.yml
@@ -16,29 +16,39 @@
 - name: Stop services before removing them.
   service: name={{ item }} state=stopped enabled=no
   with_items:
-  - nginx
-  - uwsgi
-  - proftpd
-  - munge
+    - uwsgi
+    - munge
 
-- name: Stop services before removing them.
+- name: Stop and remove slurm.
   service: name={{ item }} state=stopped enabled=no
   with_items:
-  - slurm-llnl
-  when: ansible_distribution_version <= "15.04"
+    - slurm-llnl
+  when: supervisor_manage_slurm and ansible_distribution_version <= "15.04"
 
-- name: Stop services before removing them.
+- name: Stop and remove slurm.
   service: name={{ item }} state=stopped enabled=no
   with_items:
-  - slurmd
-  - slurmctld
-  when: ansible_distribution_version > "15.04"
+    - slurmd
+    - slurmctld
+  when: supervisor_manage_slurm and ansible_distribution_version > "15.04"
 
-- name: Stop services before removing them.
+- name: Stop and remove postgresql.
   service: name={{ item }} state=stopped enabled=no
   with_items:
-  - postgresql
+    - postgresql
   when: supervisor_manage_postgres
+
+- name: Stop and remove proftpd.
+  service: name={{ item }} state=stopped enabled=no
+  with_items:
+    - proftpd
+  when: supervisor_manage_proftp
+
+- name: Stop and remove nginx.
+  service: name={{ item }} state=stopped enabled=no
+  with_items:
+    - nginx
+  when: supervisor_manage_nginx
 
 # Do not start supervisor when building docker-galaxy-stable
 - name: Start supervisor

--- a/templates/supervisor.conf.j2
+++ b/templates/supervisor.conf.j2
@@ -44,7 +44,7 @@ command         = /bin/bash -c "install -d -m 2775 -o postgres -g postgres /var/
 
 [program:postgresql]
 user            = postgres
-command         = /usr/lib/postgresql/{{ postgresql_version }}/bin/postmaster -D "{{supervisor_postgres_database_path}}"
+command         = /usr/lib/postgresql/{{ postgresql_version }}/bin/postmaster -D {{supervisor_postgres_database_path}} -c "config_file={{ supervisor_postgres_database_config }}"
 process_name    = %(program_name)s
 stopsignal      = INT
 autostart       = true

--- a/templates/supervisor.conf.j2
+++ b/templates/supervisor.conf.j2
@@ -44,7 +44,7 @@ command         = /bin/bash -c "install -d -m 2775 -o postgres -g postgres /var/
 
 [program:postgresql]
 user            = postgres
-command         = /usr/lib/postgresql/{{ postgresql_version }}/bin/postmaster -D {{supervisor_postgres_database_path}} -c "config_file={{ supervisor_postgres_database_config }}"
+command         = /usr/lib/postgresql/{{ postgresql_version }}/bin/postmaster {{ supervisor_postgres_options }}
 process_name    = %(program_name)s
 stopsignal      = INT
 autostart       = true


### PR DESCRIPTION
Changes:
Detect if proftp, posgresql, slurm or nginx were set to be controled by supervisor and deal with the systems services accordingly. 
Option to specify the Postgresql configure file added to supervisor. 