### PR TITLE
SSL for nginx, safer supervisord task, VIRTUAL_ENV + other env vars for Galaxy handler

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -86,6 +86,12 @@ nginx_additional_config : []
 nginx_serve_planemo_machine_web: false
 nginx_proxy_reports: true
 
+# nginx ssl config
+nginx_ssl: false
+# if nginx_ssl is true, set
+# nginx_ssl_cert_file to local location of SSL certificate
+# nginx_ssl_key_file to local location of SSL key
+
 galaxy_job_metrics_core: true
 galaxy_job_metrics_env: false
 galaxy_job_metrics_cpuinfo: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,3 @@
-
 - include: galaxy_root.yml
   when: galaxy_extras_config_galaxy_root
 

--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -15,3 +15,11 @@
 
 - name: "Add htpasswd file."
   template: src=htpasswd.j2 dest=/etc/nginx/htpasswd
+
+- name: "Copy SSL certificate"
+  copy: src={{ nginx_ssl_cert_file }} dest=/etc/nginx/ssl_cert.pem
+  when: nginx_ssl
+
+- name: "Copy SSL key"
+  copy: src={{ nginx_ssl_key_file }} dest=/etc/nginx/ssl_key.pem mode=0600 owner=root
+  when: nginx_ssl

--- a/tasks/supervisor.yml
+++ b/tasks/supervisor.yml
@@ -18,18 +18,21 @@
   with_items:
     - uwsgi
   when: galaxy_extras_config_uwsgi and supervisor_manage_uwsgi
+  ignore_errors: yes # ignore error that occurs when service is not installed
 
 - name: Stop and remove munge.
   service: name={{ item }} state=stopped enabled=no
   with_items:
     - munge
   when: galaxy_extras_config_slurm and supervisor_manage_slurm
+  ignore_errors: yes # ignore error that occurs when service is not installed
 
 - name: Stop and remove slurm.
   service: name={{ item }} state=stopped enabled=no
   with_items:
     - slurm-llnl
   when: galaxy_extras_config_slurm and supervisor_manage_slurm and ansible_distribution_version <= "15.04"
+  ignore_errors: yes # ignore error that occurs when service is not installed
 
 - name: Stop and remove slurm.
   service: name={{ item }} state=stopped enabled=no
@@ -37,24 +40,28 @@
     - slurmd
     - slurmctld
   when: galaxy_extras_config_slurm and supervisor_manage_slurm and ansible_distribution_version > "15.04"
+  ignore_errors: yes # ignore error that occurs when service is not installed
 
 - name: Stop and remove postgresql.
   service: name={{ item }} state=stopped enabled=no
   with_items:
     - postgresql
   when: supervisor_manage_postgres
+  ignore_errors: yes # ignore error that occurs when service is not installed
 
 - name: Stop and remove proftpd.
   service: name={{ item }} state=stopped enabled=no
   with_items:
     - proftpd
   when: galaxy_extras_config_proftpd and supervisor_manage_proftp
+  ignore_errors: yes # ignore error that occurs when service is not installed
 
 - name: Stop and remove nginx.
   service: name={{ item }} state=stopped enabled=no
   with_items:
     - nginx
   when: galaxy_extras_config_nginx and supervisor_manage_nginx
+  ignore_errors: yes # ignore error that occurs when service is not installed
 
 # Do not start supervisor when building docker-galaxy-stable
 - name: Start supervisor

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -31,9 +31,23 @@ http {
        server localhost:8080;
     }
 {% endif %}
+{% if nginx_ssl %} 
 
     server {
+      listen 80;
+
+      rewrite ^ https://$host$request_uri permanent;
+    }
+{% endif %}
+
+    server {
+{% if nginx_ssl %}
+        listen 443 default ssl;
+        ssl_certificate /etc/nginx/ssl_cert.pem;
+        ssl_certificate_key /etc/nginx/ssl_key.pem;
+{% else %}
         listen 80 default_server;
+{% endif %} 
         server_name  localhost;
 
 {% if nginx_proxy_reports %}

--- a/templates/supervisor.conf.j2
+++ b/templates/supervisor.conf.j2
@@ -127,7 +127,7 @@ autostart       = true
 autorestart     = true
 startsecs       = {{ supervisor_galaxy_startsecs }}
 user            = {{ galaxy_user_name }}
-environment     = PYTHON_EGG_CACHE={{ galxy_egg_cache }},PYTHONHOME={{ galaxy_venv_dir }}
+environment     = PYTHON_EGG_CACHE={{ galxy_egg_cache }},PYTHONHOME={{ galaxy_venv_dir }},VIRTUAL_ENV={{ galaxy_venv_dir }}{%- if galaxy_handler_env is defined %},{% endif %}{{ galaxy_handler_env }}
 startretries    = {{ supervisor_galaxy_startretries }}
 
 {% if supervisor_manage_reports %}


### PR DESCRIPTION
* Add support for nginx SSL config
* Make supervisord task ignore errors when disabled absent services
* Add VIRTUAL_ENV to galaxy supervisord config
* Add galaxy_handler_env var to allow extra environment vars for the handler