### PR TITLE
Proxy interactive environments

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,6 +30,10 @@ galaxy_extras_ie_jupyter_image: bgruening/docker-jupyter-notebook:16.01
 galaxy_extras_ie_fetch_rstudio: false
 galaxy_extras_ie_rstudio_image: erasche/docker-rstudio-notebook:15.10
 
+# The storage backend to use for docker-in-docker.
+# aufs on parent docker cannot be combined with aufs in child docker
+galaxy_extras_docker_storage_backend: aufs
+
 galaxy_docker_enabled: false
 galaxy_docker_sudo: false
 galaxy_docker_volumes_from: galaxy
@@ -84,6 +88,7 @@ nginx_upload_store_path: "/tmp/nginx_upload_store"
 # If all apps should be served on a common subdirectory, use nginx_prefix_location: /your_common_dir
 nginx_prefix_location: ""
 nginx_galaxy_location: "{{ nginx_prefix_location }}"
+nginx_interactive_environment_location: "gie_proxy"
 nginx_reports_location: "{{ nginx_prefix_location }}/reports"
 nginx_planemo_web_location: "{{ nginx_prefix_location }}/planemo"
 nginx_ide_location: "{{ nginx_prefix_location }}/ide"

--- a/tasks/pbs.yml
+++ b/tasks/pbs.yml
@@ -12,7 +12,7 @@
   register: requirements_txt
 
 - name: Fetch DRMAA egg for Galaxy
-  shell: "{{ galaxy_venv_dir }}/bin/python {{ galaxy_root }}/scripts/fetch_eggs.py -e drmaa -c {{ galaxy_config_file }}"
+  shell: "{{ galaxy_venv_dir }}/bin/python {{ galaxy_server_dir }}/scripts/fetch_eggs.py -e drmaa -c {{ galaxy_config_file }}"
   when: not requirements_txt.stat.exists
 
 # If job_conf.xml is installed before running galaxyprojectdotorg.galaxy, this would already be installed.

--- a/tasks/supervisor.yml
+++ b/tasks/supervisor.yml
@@ -12,6 +12,7 @@
 
 - name: Stop supervisor
   service: name=supervisor state=stopped
+  tags: stop_supervisor
 
 - name: Stop and remove uwsgi.
   service: name={{ item }} state=stopped enabled=no

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -139,7 +139,7 @@ http {
             proxy_set_header Connection "upgrade";
         }
 
-        location ~ ^{{ nginx_galaxy)location }}/plugins/visualizations/(?<vis_name>.+?)/static/(?<static_file>.*?)$ {
+        location ~ ^{{ nginx_galaxy_location }}/plugins/visualizations/(?<vis_name>.+?)/static/(?<static_file>.*?)$ {
             alias {{ galaxy_server_dir }}/config/plugins/visualizations/$vis_name/static/$static_file;
         }
 

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -125,11 +125,25 @@ http {
             expires 24h;
         }
 
-        location ~ ^{{ nginx_galaxy_location }}/plugins/visualizations/(?<vis_name>.+?)/static/(?<static_file>.*?)$ {
+        location {{ nginx_galaxy_location }}/{{ nginx_interactive_environment_location }} {
+            proxy_pass http://localhost:8800/{{ nginx_interactive_environment_location }};
+            proxy_redirect off;
+        }
+
+        # IPython specific. Other IEs may require their own routes.
+        location {{ nginx_galaxy_location }}/{{ nginx_interactive_environment_location }}/ipython/api/kernels {
+            proxy_pass http://localhost:8800/{{ nginx_interactive_environment_location }}/ipython/api/kernels;
+            proxy_redirect off;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+        }
+
+        location ~ ^/plugins/visualizations/(?<vis_name>.+?)/static/(?<static_file>.*?)$ {
             alias {{ galaxy_server_dir }}/config/plugins/visualizations/$vis_name/static/$static_file;
         }
 
-        location ~ ^{{ nginx_galaxy_location }}/plugins/interactive_environments/(?<ie_name>.+?)/static/(?<static_file>.*?)$ {
+        location ~ ^/plugins/interactive_environments/(?<ie_name>.+?)/static/(?<static_file>.*?)$ {
             alias {{ galaxy_server_dir }}/config/plugins/interactive_environments/$ie_name/static/$static_file;
         }
 

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -139,12 +139,8 @@ http {
             proxy_set_header Connection "upgrade";
         }
 
-        location ~ ^{{ nginx_galaxy_location }}/plugins/visualizations/(?<vis_name>.+?)/static/(?<static_file>.*?)$ {
-            alias {{ galaxy_server_dir }}/config/plugins/visualizations/$vis_name/static/$static_file;
-        }
-
-        location ~ ^{{ nginx_galaxy_location }}/plugins/interactive_environments/(?<ie_name>.+?)/static/(?<static_file>.*?)$ {
-            alias {{ galaxy_server_dir }}/config/plugins/interactive_environments/$ie_name/static/$static_file;
+        location ~ ^{{ nginx_galaxy_location }}/plugins/(?<plug_type>.+?)/(?<vis_name>.+?)/static/(?<static_file>.*?)$ {
+            alias {{ galaxy_server_dir }}/config/plugins/$plug_type/$vis_name/static/$static_file;
         }
 
 {% if galaxy_extras_config_nginx_upload == True %}

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -139,11 +139,11 @@ http {
             proxy_set_header Connection "upgrade";
         }
 
-        location ~ ^/plugins/visualizations/(?<vis_name>.+?)/static/(?<static_file>.*?)$ {
+        location ~ ^{{ nginx_galaxy)location }}/plugins/visualizations/(?<vis_name>.+?)/static/(?<static_file>.*?)$ {
             alias {{ galaxy_server_dir }}/config/plugins/visualizations/$vis_name/static/$static_file;
         }
 
-        location ~ ^/plugins/interactive_environments/(?<ie_name>.+?)/static/(?<static_file>.*?)$ {
+        location ~ ^{{ nginx_galaxy_location }}/plugins/interactive_environments/(?<ie_name>.+?)/static/(?<static_file>.*?)$ {
             alias {{ galaxy_server_dir }}/config/plugins/interactive_environments/$ie_name/static/$static_file;
         }
 

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -125,11 +125,11 @@ http {
             expires 24h;
         }
 
-        location ~ ^/plugins/visualizations/(?<vis_name>.+?)/static/(?<static_file>.*?)$ {
+        location ~ ^{{ nginx_galaxy_location }}/plugins/visualizations/(?<vis_name>.+?)/static/(?<static_file>.*?)$ {
             alias {{ galaxy_server_dir }}/config/plugins/visualizations/$vis_name/static/$static_file;
         }
 
-        location ~ ^/plugins/interactive_environments/(?<ie_name>.+?)/static/(?<static_file>.*?)$ {
+        location ~ ^{{ nginx_galaxy_location }}/plugins/interactive_environments/(?<ie_name>.+?)/static/(?<static_file>.*?)$ {
             alias {{ galaxy_server_dir }}/config/plugins/interactive_environments/$ie_name/static/$static_file;
         }
 

--- a/templates/supervisor.conf.j2
+++ b/templates/supervisor.conf.j2
@@ -172,7 +172,7 @@ redirect_stderr = true
 {% if supervisor_manage_docker %}
 [program:docker]
 directory       = /
-command         = /usr/bin/docker daemon --host=unix:///var/run/docker.sock --host=tcp://0.0.0.0:2375 -s aufs
+command         = /usr/bin/docker daemon --host=unix:///var/run/docker.sock --host=tcp://0.0.0.0:2375 -s {{ galaxy_extras_docker_storage_backend }}
 autostart       = {{ supervisor_docker_autostart }}
 autorestart     = {{ supervisor_docker_autorestart }}
 user            = root


### PR DESCRIPTION
With these changes port 8800 doesn't need to be exposed anymore in the docker image if you just want to server jupyter/ipython. Doesn't work for RStudio unfortunately.