### PR TITLE
Enable role testing with the Galaxy Docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,15 @@ install:
   # Add ansible.cfg to pick up roles path.
   - printf '[defaults]\nroles_path = ../' > ansible.cfg
 
+  # download the Galaxy Docker image and build it to test the playrole
+  - mkdir $HOME/galaxy-docker
+  - wget -q -O - https://github.com/bgruening/docker-galaxy-stable/archive/master.tar.gz | tar xzf - --strip-components=1 -C $HOME/galaxy-docker
+  # remove the submodule role
+  - rm $HOME/galaxy-docker/galaxy/roles/galaxyprojectdotorg.galaxyextras/* -rf
+
 script:
   # Check the role/playbook's syntax.
   - ansible-playbook -i "localhost," tests/syntax.yml --syntax-check
+  - cp ./* $HOME/galaxy-docker/galaxy/roles/galaxyprojectdotorg.galaxyextras/
+  - ls -l $HOME/galaxy-docker/galaxy/roles/galaxyprojectdotorg.galaxyextras/
+  - cd $HOME/galaxy-docker/galaxy && docker build -t galaxy .


### PR DESCRIPTION
As promised this PR will test the ansible role if it does not break the Docker Galaxy Image.

Testing now is a small chain of trust.

* bioblend has it's own unit-tests which tests a lot of functionality of a running Galaxy Server
* Galaxy Docker is using bioblend to run all tests against the Docker Image, ensuring a working Docker Image (which consumes a stable version of `ansible-galaxy-extras`)
* `ansible-galaxy-extras` is using a stable version of the Galaxy Docker Image and replaces the fixed stable `ansible-galaxy-extras`-role with a development version which need to be tested

This should ensure that all projects will work and are compatible. I hope it not to complex.
