### PR TITLE
Step toward rationalizing logging parameters...

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -56,12 +56,14 @@ galaxy_reports_config_file: "{{ galaxy_config_dir }}/reports_wsgi.ini"
 galaxy_toolshed_config_file: "{{ galaxy_config_dir }}/tool_shed.ini"
 galaxy_config_file: "{{ galaxy_config_dir }}/galaxy.ini"
 galaxy_reports_port: "9001"
+galaxy_reports_log: "{{ galaxy_log_dir }}/reports.log"
 
 galaxy_db_port: "5432"
 galaxy_database_connection: "postgres://{{ galaxy_user_name }}@localhost:{{ galaxy_db_port }}/galaxy"
 
 # Port to serve uwsgi on.
 galaxy_uwsgi: true
+uwsgi_log: "{{ galaxy_log_dir }}/uwsgi.log"
 uwsgi_port: 4001
 
 # Set to true to write thread/process number into supervisor config. If false, uses environmental variables.
@@ -77,6 +79,8 @@ galaxy_handler_processes: 2
 
 startup_export_user_files: true
 startup_chown_on_directory: ""
+
+slurm_log_dir: "{{ galaxy_log_dir }}"
 
 # Nginx configuration.
 nginx_conf_path: /etc/nginx/nginx.conf

--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -119,12 +119,12 @@ function start_supervisor {
         if [[ $NONUSE != *"slurmctld"* ]]
         then
             echo "Starting slurmctld"
-            /usr/sbin/slurmctld -L /home/galaxy/slurmctld.log
+            /usr/sbin/slurmctld -L {{ slurm_log_dir }}/slurmctld.log
         fi
         if [[ $NONUSE != *"slurmd"* ]]
         then
             echo "Starting slurmd"
-            /usr/sbin/slurmd -L /home/galaxy/slurmd.log
+            /usr/sbin/slurmd -L {{ slurm_log_dir }}/slurmd.log
         fi
 
         # We need to run munged regardless
@@ -158,9 +158,9 @@ fi
 # Enable verbose output
 if [ `echo ${GALAXY_LOGGING:-'no'} | tr [:upper:] [:lower:]` = "full" ]
     then
-        tail -f /var/log/supervisor/* /var/log/nginx/* {{ galaxy_home_dir }}/*.log
+        tail -f /var/log/supervisor/* /var/log/nginx/* {{ galaxy_log_dir }}/*.log
     else
-        tail -f {{ galaxy_home_dir }}/*.log
+        tail -f {{ galaxy_log_dir }}/*.log
 fi
 
 # Disable authentication of Galaxy reports

--- a/templates/supervisor.conf.j2
+++ b/templates/supervisor.conf.j2
@@ -82,9 +82,9 @@ priority        = 200
 [program:galaxy_web]
 {% if galaxy_uwsgi %}
 {% if galaxy_uwsgi_static_conf %}
-command         = {{ galaxy_venv_dir }}/bin/uwsgi --virtualenv {{ galaxy_venv_dir }} --ini-paste {{ galaxy_config_file }} --logdate --master --processes {{ galaxy_web_processes }} --threads {{ uwsgi_threads }} --logto {{ galaxy_log_dir }}/uwsgi.log --socket 127.0.0.1:4001 --pythonpath lib --stats 127.0.0.1:9191
+command         = {{ galaxy_venv_dir }}/bin/uwsgi --virtualenv {{ galaxy_venv_dir }} --ini-paste {{ galaxy_config_file }} --logdate --master --processes {{ galaxy_web_processes }} --threads {{ uwsgi_threads }} --logto {{ uwsgi_log }} --socket 127.0.0.1:4001 --pythonpath lib --stats 127.0.0.1:9191
 {% else %}
-command         = {{ galaxy_venv_dir }}/bin/uwsgi --virtualenv {{ galaxy_venv_dir }} --ini-paste {{ galaxy_config_file }} --logdate --master --processes %(ENV_UWSGI_PROCESSES)s --threads %(ENV_UWSGI_THREADS)s --logto %(ENV_GALAXY_HOME)s/uwsgi.log --socket 127.0.0.1:4001 --pythonpath lib --stats 127.0.0.1:9191
+command         = {{ galaxy_venv_dir }}/bin/uwsgi --virtualenv {{ galaxy_venv_dir }} --ini-paste {{ galaxy_config_file }} --logdate --master --processes %(ENV_UWSGI_PROCESSES)s --threads %(ENV_UWSGI_THREADS)s --logto {{ uwsgi_log }} --socket 127.0.0.1:4001 --pythonpath lib --stats 127.0.0.1:9191
 {% endif %}
 directory       = {{ galaxy_server_dir }}
 umask           = 022
@@ -132,7 +132,7 @@ startretries    = {{ supervisor_galaxy_startretries }}
 
 {% if supervisor_manage_reports %}
 [program:reports]
-command         = {{ galaxy_venv_dir }}/bin/python ./scripts/paster.py serve {{ galaxy_reports_config_file }} --server-name=main --pid-file={{ galaxy_log_dir }}/reports.pid --log-file={{ galaxy_log_dir }}/reports.log
+command         = {{ galaxy_venv_dir }}/bin/python ./scripts/paster.py serve {{ galaxy_reports_config_file }} --server-name=main --pid-file={{ galaxy_log_dir }}/reports.pid --log-file={{ galaxy_reports_log }}
 directory       = {{ galaxy_server_dir }}
 process_name    = reports
 umask           = 022


### PR DESCRIPTION
 - Introduce uwsgi_log, slurm_log_dir, and galaxy_reports_log parameters
 - Fix startup script to respect galaxy_log_dir (if it differs from galaxy_home)
 - Another small uwsgi log tweak