### PR TITLE
Adding ability to place password infront of nginx proxy

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -67,6 +67,11 @@ nginx_conf_path: /etc/nginx/nginx.conf
 nginx_conf_directory: /etc/nginx/conf.d
 nginx_upload_store_path: "/tmp/nginx_upload_store"
 
+#web security
+nginx_use_passwords: False
+nginx_htpasswds:
+  - "admin:WiBKbsJTSQ8dc"
+
 ## Development Box Configuration
 # Configure nginx to setup a proxy to an IDE.
 nginx_proxy_ide: false

--- a/templates/htpasswd.j2
+++ b/templates/htpasswd.j2
@@ -1,1 +1,3 @@
-admin:WiBKbsJTSQ8dc
+{% for p in nginx_htpasswds %}
+{{ p }}
+{% endfor %}

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -36,6 +36,11 @@ http {
         listen 80 default_server;
         server_name  localhost;
 
+{% if nginx_use_passwords %}
+        auth_basic      "devbox";
+        auth_basic_user_file  /etc/nginx/htpasswd;
+{% endif %}
+
 {% if nginx_proxy_reports %}
         # enable reports under :80/reports/
         # if the file /etc/nginx/htpasswd exists authentification is enabled
@@ -155,7 +160,18 @@ http {
             }
             rewrite "" $dst;
         }
-
+{% if nginx_use_passwords %}
+        location /api {
+          auth_basic off;
+          proxy_pass http://galaxy_web_app/api;
+          proxy_set_header X-Forwarded-Host $host;
+          proxy_set_header X-Forwarded-For  $proxy_add_x_forwarded_for;     
+      {% if galaxy_admin_user is defined and galaxy_admin_user %}
+          # hard-code a fixed user to pass to Galaxy to auto-login
+          proxy_set_header REMOTE_USER '{{ galaxy_admin_user }}';
+      {% endif %}
+        }
+{% endif %}
         error_page 502  /502.html;
         location = /502.html {
             root  /root/;


### PR DESCRIPTION
Additional optional config to add a basic_auth in front of nginx server. In cases, like the planemo-machine, authentication (at the galaxy level) is done automatically. This puts a small barrier to entry in front of the UI elements (the /api path gets a pass)