### PR TITLE
Use the same galaxy environment for UWSGI and non-UWSGI setups.

### DIFF
--- a/templates/supervisor.conf.j2
+++ b/templates/supervisor.conf.j2
@@ -21,7 +21,7 @@ stopasgroup     = true
 [program:slurmctld]
 user=root
 command=/bin/bash -c "/usr/bin/python /usr/sbin/configure_slurm.py && /usr/sbin/slurmctld -D -L {{supervisor_slurm_config_dir}}/slurmctld.log"
-redirect_stderr=true 
+redirect_stderr=true
 autorestart     = true
 priority=200
 stopasgroup     = true
@@ -29,7 +29,7 @@ stopasgroup     = true
 [program:slurmd]
 user=root
 command=/usr/sbin/slurmd -D -L {{supervisor_slurm_config_dir}}/slurmd.log
-redirect_stderr=true 
+redirect_stderr=true
 autorestart     = true
 priority=300
 {% endif %}
@@ -107,7 +107,7 @@ autostart       = true
 autorestart     = true
 startsecs       = {{ supervisor_galaxy_startsecs }}
 user            = {{ galaxy_user_name }}
-environment     = PYTHON_EGG_CACHE={{ galxy_egg_cache }}
+environment     = PATH={{ galaxy_venv_dir }}:{{ galaxy_venv_dir }}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin,PYTHON_EGG_CACHE={{ galxy_egg_cache }},PYTHONPATH={{ galaxy_server_dir }}/eggs/PasteDeploy-1.5.0-py2.7.egg
 startretries    = {{ supervisor_galaxy_startretries }}
 # needed for bash wrapper
 stopasgroup     = true


### PR DESCRIPTION
Otherwise, getting the following error:
```
Traceback (most recent call last):
  File "/opt/galaxy/galaxy-app/tools/data_source/upload.py", line 18, in <module>
    import galaxy.model  # noqa
  File "/opt/galaxy/galaxy-app/lib/galaxy/model/__init__.py", line 21, in <module>
    from sqlalchemy import and_, func, not_, or_, true, join, select
ImportError: No module named sqlalchemy
Traceback (most recent call last):
  File "/opt/galaxy/galaxy-app/database/jobs/000/1/set_metadata_jruANb.py", line 1, in <module>
    from galaxy_ext.metadata.set_metadata import set_metadata; set_metadata()
  File "/opt/galaxy/galaxy-app/lib/galaxy_ext/metadata/set_metadata.py", line 23, in <module>
    from sqlalchemy.orm import clear_mappers
ImportError: No module named sqlalchemy.orm
```