### PR TITLE
Allow sharing nodes and set nativeSpecification for slurm.

### DIFF
--- a/templates/configure_slurm.py.j2
+++ b/templates/configure_slurm.py.j2
@@ -77,7 +77,7 @@ SlurmctldDebug=3
 SlurmdDebug=3
 #SlurmdLogFile=
 NodeName=$hostname CPUs=$cpus RealMemory=$memory State=UNKNOWN
-PartitionName=debug Nodes=$hostname Default=YES MaxTime=INFINITE State=UP
+PartitionName=debug Nodes=$hostname Default=YES MaxTime=INFINITE State=UP Shared=YES
 '''
 
 try:

--- a/templates/job_conf.xml.j2
+++ b/templates/job_conf.xml.j2
@@ -27,6 +27,7 @@
       <destination id="cluster" runner="pbs">
   {% elif galaxy_extras_config_slurm == True %}
       <destination id="cluster" runner="slurm">
+          <param id="nativeSpecification" from_environ="NATIVE_SPEC">--ntasks=1 --share</param>
   {% endif %}
 
   {% if galaxy_source_shellrc %}


### PR DESCRIPTION
The default settings up to now result in GALAXY_SLOTS=1. With this PR users can
control the nativeSpecification parameter in the job_conf.xml using the
environmental variable NATIVE_SPEC.

We also set Shared=YES in the configure_clurm.py script. Shared=YES does not change the default
(https://computing.llnl.gov/linux/slurm/cons_res_share.html) unless --share
is provided to srun or the nativeSpecification in job_conf.xml.