### PR TITLE
Make control_machine and partition name configurable with env vars

### DIFF
--- a/templates/configure_slurm.py.j2
+++ b/templates/configure_slurm.py.j2
@@ -94,6 +94,7 @@ def main():
     template_params = {
         "hostname": hostname,
         "control_machine": environ.get('SLURM_CONTROL_MACHINE', hostname),
+        "cluster_name": environ.get('SLURM_CLUSTER_NAME', 'cluster'),
         "user": environ.get('SLURM_USER_NAME', '{{ galaxy_user_name }}'),
         "cpus": environ.get("SLURM_CPUS", cpus),
         "partition_name": environ.get('SLURM_PARTITION_NAME', 'debug'),

--- a/templates/configure_slurm.py.j2
+++ b/templates/configure_slurm.py.j2
@@ -9,7 +9,7 @@ SLURM_CONFIG_TEMPLATE = '''
 # Put this file on all nodes of your cluster.
 # See the slurm.conf man page for more information.
 #
-ControlMachine=$hostname
+ControlMachine=$control_machine
 #ControlAddr=
 #BackupController=
 #BackupAddr=
@@ -62,7 +62,7 @@ SelectTypeParameters=CR_Core_Memory
 AccountingStorageType=accounting_storage/none
 #AccountingStorageUser=
 AccountingStoreJobComment=YES
-ClusterName=cluster
+ClusterName=$cluster_name
 #DebugFlags=
 #JobCompHost=
 #JobCompLoc=
@@ -77,7 +77,7 @@ SlurmctldDebug=3
 SlurmdDebug=3
 #SlurmdLogFile=
 NodeName=$hostname CPUs=$cpus RealMemory=$memory State=UNKNOWN
-PartitionName=debug Nodes=$hostname Default=YES MaxTime=INFINITE State=UP Shared=YES
+PartitionName=$partition_name Nodes=$hostname Default=YES MaxTime=INFINITE State=UP Shared=YES
 '''
 
 try:
@@ -90,10 +90,13 @@ except:
     mem = psutil.virtual_memory().total
 
 def main():
+    hostname = gethostname()
     template_params = {
-        "hostname": gethostname(),
-        "user": '{{ galaxy_user_name }}',
+        "hostname": hostname,
+        "control_machine": environ.get('SLURM_CONTROL_MACHINE', hostname),
+        "user": environ.get('SLURM_USER_NAME', '{{ galaxy_user_name }}'),
         "cpus": environ.get("SLURM_CPUS", cpus),
+        "partition_name": environ.get('SLURM_PARTITION_NAME', 'debug'),
         "memory": environ.get("SLURM_MEMORY", int(mem / (1024 * 1024)))
     }
     config_contents = Template(SLURM_CONFIG_TEMPLATE).substitute(template_params)


### PR DESCRIPTION
This should allow us to spin on some slurm images to form an ad-hoc slurm cluster for docker galaxy.

Ping @bgruening @afgane 