### PR TITLE
add state=file

### DIFF
--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -14,4 +14,4 @@
   template: src=nginx_ide.conf.j2 dest={{ nginx_conf_directory }}/ide.conf
 
 - name: "Add htpasswd file."
-  template: src=htpasswd.j2 dest=/etc/nginx/htpasswd
+  template: src=htpasswd.j2 dest=/etc/nginx/htpasswd state=file


### PR DESCRIPTION
I'm not sure why this is needed, but I see some issues on Dockerhub.
This bug is described here: https://github.com/ansible/ansible/issues/13652