### PR TITLE
Hotfix: adds bool filters to booleans in when statements with and operators

### DIFF
--- a/tasks/slurm.yml
+++ b/tasks/slurm.yml
@@ -17,13 +17,13 @@
   apt: pkg={{ item }} state={{ galaxy_extras_apt_package_state }}
   with_items:
     - slurm-llnl-torque 
-  when: galaxy_extras_install_packages and ansible_distribution_version <= "15.04"
+  when: galaxy_extras_install_packages|bool and ansible_distribution_version <= "15.04"
 
 - name: Install SLURM system packages
   apt: pkg={{ item }} state={{ galaxy_extras_apt_package_state }}
   with_items:
     - slurm-wlm-torque 
-  when: galaxy_extras_install_packages and ansible_distribution_version >= "15.04"
+  when: galaxy_extras_install_packages|bool and ansible_distribution_version >= "15.04"
 
 - name: Create Munge Key
   command: /usr/sbin/create-munge-key creates=/etc/munge/munge.key

--- a/tasks/supervisor.yml
+++ b/tasks/supervisor.yml
@@ -18,26 +18,26 @@
   service: name={{ item }} state=stopped enabled=no
   with_items:
     - uwsgi
-  when: galaxy_extras_config_uwsgi and supervisor_manage_uwsgi
+  when: galaxy_extras_config_uwsgi|bool and supervisor_manage_uwsgi|bool
 
 - name: Stop and remove munge.
   service: name={{ item }} state=stopped enabled=no
   with_items:
     - munge
-  when: galaxy_extras_config_slurm and supervisor_manage_slurm
+  when: galaxy_extras_config_slurm|bool and supervisor_manage_slurm|bool
 
 - name: Stop and remove slurm.
   service: name={{ item }} state=stopped enabled=no
   with_items:
     - slurm-llnl
-  when: galaxy_extras_config_slurm and supervisor_manage_slurm and ansible_distribution_version <= "15.04"
+  when: galaxy_extras_config_slurm|bool and supervisor_manage_slurm|bool and ansible_distribution_version <= "15.04"
 
 - name: Stop and remove slurm.
   service: name={{ item }} state=stopped enabled=no
   with_items:
     - slurmd
     - slurmctld
-  when: galaxy_extras_config_slurm and supervisor_manage_slurm and ansible_distribution_version > "15.04"
+  when: galaxy_extras_config_slurm|bool and supervisor_manage_slurm|bool and ansible_distribution_version > "15.04"
 
 - name: Stop and remove postgresql.
   service: name={{ item }} state=stopped enabled=no
@@ -49,13 +49,13 @@
   service: name={{ item }} state=stopped enabled=no
   with_items:
     - proftpd
-  when: galaxy_extras_config_proftpd and supervisor_manage_proftp
+  when: galaxy_extras_config_proftpd|bool and supervisor_manage_proftp|bool
 
 - name: Stop and remove nginx.
   service: name={{ item }} state=stopped enabled=no
   with_items:
     - nginx
-  when: galaxy_extras_config_nginx and supervisor_manage_nginx
+  when: galaxy_extras_config_nginx|bool and supervisor_manage_nginx|bool
 
 # Do not start supervisor when building docker-galaxy-stable
 - name: Start supervisor

--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -11,7 +11,7 @@ cd {{ galaxy_server_dir }}
 . {{ galaxy_venv_dir }}/bin/activate
 umount /var/lib/docker
 
-{% if startup_export_user_files is defined and startup_export_user_files %}
+{% if startup_export_user_files is defined and startup_export_user_files|bool %}
 # If /export/ is mounted, export_user_files file moving all data to /export/
 # symlinks will point from the original location to the new path under /export/
 # If /export/ is not given, nothing will happen in that step
@@ -45,7 +45,7 @@ if [ -e /export/postgresql/ ];
 fi
 
 
-{% if galaxy_extras_config_condor %}
+{% if galaxy_extras_config_condor|bool %}
 if [ "x$ENABLE_CONDOR" != "x" ]
 then
     echo "Enabling Condor"
@@ -58,7 +58,7 @@ fi
 {% endif %}
 
 
-{% if startup_chown_on_directory is defined and startup_chown_on_directory %}
+{% if startup_chown_on_directory is defined and startup_chown_on_directory|bool %}
 if [ -e {{ startup_chown_on_directory }}  ];
 then
     old_uid=`stat -c '%u' "{{ galaxy_home_dir }}"`
@@ -104,21 +104,21 @@ fi
 function start_supervisor {
     supervisord -c /etc/supervisor/supervisord.conf
     sleep 5
-    {% if supervisor_manage_proftp %}
+    {% if supervisor_manage_proftp|bool %}
     if [[ $NONUSE != *"proftp"* ]]
     then
         echo "Starting ProFTP"
         supervisorctl start proftpd
     fi
     {% endif %}
-    {% if supervisor_manage_reports %}
+    {% if supervisor_manage_reports|bool %}
     if [[ $NONUSE != *"reports"* ]]
     then
         echo "Starting Galaxy reports webapp"
         supervisorctl start reports
     fi
     {% endif %}
-    {% if supervisor_manage_ie_proxy %}
+    {% if supervisor_manage_ie_proxy|bool %}
     if [[ $NONUSE != *"nodejs"* ]]
     then
         echo "Starting nodejs"
@@ -127,7 +127,7 @@ function start_supervisor {
     {% endif %}
 
 
-    {% if supervisor_manage_slurm %}
+    {% if supervisor_manage_slurm|bool %}
         if [[ $NONUSE != *"slurmctld"* ]]
         then
             echo "Starting slurmctld"

--- a/templates/supervisor.conf.j2
+++ b/templates/supervisor.conf.j2
@@ -1,16 +1,16 @@
 [supervisord]
 nodaemon=false
 
-{% if supervisor_webserver %}
+{% if supervisor_webserver|bool %}
 [inet_http_server]
 port={{ supervisor_webserver_port }}
-{% if supervisor_webserver_username %}
+{% if supervisor_webserver_username|bool %}
 username={{ supervisor_webserver_username }}
 password={{ supervisor_webserver_password }}
 {% endif %}
 {% endif %}
 
-{% if supervisor_manage_slurm %}
+{% if supervisor_manage_slurm|bool %}
 [program:munge]
 user=root
 command=/bin/bash -c "mkdir -p /var/run/munge && /usr/sbin/munged -F"
@@ -34,7 +34,7 @@ autorestart     = true
 priority        = 300
 {% endif %}
 
-{% if galaxy_extras_config_condor %}
+{% if galaxy_extras_config_condor|bool %}
 [program:condor]
 user=root
 command=condor_master
@@ -44,7 +44,7 @@ priority        = 100
 {% endif %}
 
 
-{% if supervisor_manage_postgres %}
+{% if supervisor_manage_postgres|bool %}
 {% if ansible_virtualization_type != "docker" %}
 [program:pre_postgresql]
 user            = root
@@ -63,7 +63,7 @@ redirect_stderr = true
 priority        = 100
 {% endif %}
 
-{% if supervisor_manage_proftp %}
+{% if supervisor_manage_proftp|bool %}
 [program:proftpd]
 {% if proftpd_nat_masquerade %}
 command         = bash -c " export MASQUERADE_ADDRESS={{ proftpd_masquerade_address }} && /usr/sbin/proftpd -n -c {{proftpd_conf_path}}"
@@ -76,7 +76,7 @@ stopasgroup     = true
 killasgroup     = true
 {% endif %}
 
-{% if supervisor_manage_nginx %}
+{% if supervisor_manage_nginx|bool %}
 [program:nginx]
 command         = /usr/sbin/nginx
 directory       = /
@@ -90,8 +90,8 @@ priority        = 200
 {% endif %}
 
 [program:galaxy_web]
-{% if galaxy_uwsgi %}
-{% if galaxy_uwsgi_static_conf %}
+{% if galaxy_uwsgi|bool %}
+{% if galaxy_uwsgi_static_conf|bool %}
 command         = {{ galaxy_venv_dir }}/bin/uwsgi --virtualenv {{ galaxy_venv_dir }} --ini-paste {{ galaxy_config_file }} --logdate --master --processes {{ galaxy_web_processes }} --threads {{ uwsgi_threads }} --logto {{ uwsgi_log }} --socket 127.0.0.1:4001 --pythonpath lib --stats 127.0.0.1:9191
 {% else %}
 command         = {{ galaxy_venv_dir }}/bin/uwsgi --virtualenv {{ galaxy_venv_dir }} --ini-paste {{ galaxy_config_file }} --logdate --master --processes %(ENV_UWSGI_PROCESSES)s --threads %(ENV_UWSGI_THREADS)s --logto {{ uwsgi_log }} --socket 127.0.0.1:4001 --pythonpath lib --stats 127.0.0.1:9191
@@ -124,7 +124,7 @@ stopasgroup     = true
 {% endif %}
 
 [program:handler]
-{% if not galaxy_paste_handlers %}
+{% if not galaxy_paste_handlers|bool %}
 command         = {{ galaxy_venv_dir }}/bin/python ./lib/galaxy/main.py -c {{ galaxy_config_file }} --server-name=handler%(process_num)s --log-file={{ galaxy_log_dir }}/handler%(process_num)s.log
 {% else %}
 command         = {{ galaxy_venv_dir }}/bin/python ./scripts/paster.py serve {{ galaxy_config_file }} --server-name=handler%(process_num)s --pid-file={{ galaxy_log_dir }}/handler%(process_num)s.pid --log-file={{ galaxy_log_dir }}/handler%(process_num)s.log
@@ -139,7 +139,7 @@ startsecs       = {{ supervisor_galaxy_startsecs }}
 user            = {{ galaxy_user_name }}
 startretries    = {{ supervisor_galaxy_startretries }}
 
-{% if supervisor_manage_reports %}
+{% if supervisor_manage_reports|bool %}
 [program:reports]
 command         = {{ galaxy_venv_dir }}/bin/python ./scripts/paster.py serve {{ galaxy_reports_config_file }} --server-name=main --pid-file={{ galaxy_log_dir }}/reports.pid --log-file={{ galaxy_reports_log }}
 directory       = {{ galaxy_server_dir }}
@@ -152,7 +152,7 @@ user            = {{ galaxy_user_name }}
 startretries    = {{ supervisor_galaxy_startretries }}
 {% endif %}
 
-{% if supervisor_manage_toolshed %}
+{% if supervisor_manage_toolshed|bool %}
 [program:toolshed]
 command         = {{ galaxy_venv_dir }}/bin/python ./scripts/paster.py serve {{ galaxy_toolshed_config_file }} --server-name=main --pid-file={{ galaxy_log_dir }}/toolshed.pid --log-file={{ galaxy_log_dir }}/toolshed.log
 directory       = {{ galaxy_server_dir }}
@@ -165,7 +165,7 @@ user            = {{ galaxy_user_name }}
 startretries    = {{ supervisor_galaxy_startretries }}
 {% endif %}
 
-{% if supervisor_manage_ie_proxy %}
+{% if supervisor_manage_ie_proxy|bool %}
 [program:galaxy_nodejs_proxy]
 directory       = {{ galaxy_server_dir }}
 command         = {{ galaxy_server_dir }}/lib/galaxy/web/proxy/js/lib/main.js --sessions database/session_map.sqlite --ip 0.0.0.0 --port 8800
@@ -176,7 +176,7 @@ startsecs       = 5
 redirect_stderr = true
 {% endif %}
 
-{% if supervisor_manage_docker %}
+{% if supervisor_manage_docker|bool %}
 [program:docker]
 directory       = /
 command         = /usr/bin/docker daemon --host=unix:///var/run/docker.sock --host=tcp://0.0.0.0:2375 -s {{ galaxy_extras_docker_storage_backend }}
@@ -188,7 +188,7 @@ redirect_stderr = true
 {% endif %}
 
 [group:galaxy]
-{% if supervisor_manage_ie_proxy %}
+{% if supervisor_manage_ie_proxy|bool %}
 programs = handler, galaxy_web, galaxy_nodejs_proxy
 {% else %}
 programs = handler, galaxy_web


### PR DESCRIPTION
This fixes issue #81 (explained in detail there). Simply adds `|bool` filters to boolean variables in _when_ statements when the statement has an _and_ operator between the variables.