### PR TITLE
Improvements for startup and export_files jinja templates

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,7 @@ galaxy_extras_config_slurm: true
 galaxy_extras_config_pbs: false
 galaxy_extras_config_condor: false
 galaxy_extras_config_condor_docker: false
+galaxy_extras_config_docker: false
 galaxy_extras_config_supervisor: true
 galaxy_extras_config_galaxy_root: true
 galaxy_extras_config_galaxy_job_metrics: true
@@ -190,5 +191,3 @@ supervisor_webserver_username: null
 supervisor_webserver_password: changeme
 
 use_pbkdf2: false
-use_slurm: true
-use_docker: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -190,3 +190,4 @@ supervisor_webserver_username: null
 supervisor_webserver_password: changeme
 
 use_pbkdf2: false
+use_slurm: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -191,3 +191,4 @@ supervisor_webserver_password: changeme
 
 use_pbkdf2: false
 use_slurm: true
+use_docker: true

--- a/templates/export_user_files.py.j2
+++ b/templates/export_user_files.py.j2
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     for filename in os.listdir('/export/'):
         if filename.startswith('welcome'):
             export_file = os.path.join( '/export/', filename)
-            image_file = os.path.join('/etc/galaxy/web/', filename)
+            image_file = os.path.join('{{ galaxy_config_dir }}/web/', filename)
             shutil.copy(export_file, image_file)
 
     if not os.path.exists( '/export{{ galaxy_server_dir }}/' ):
@@ -65,7 +65,7 @@ if __name__ == "__main__":
     # replace Galaxy's copy with these. Use symbolic link instead of copying so
     # deployer can update and reload Galaxy and changes will be reflected.
     for config in [ 'galaxy.ini', 'job_conf.xml' ]:
-        image_config = os.path.join('/etc/galaxy/', config)
+        image_config = os.path.join('{{ galaxy_config_dir }}/', config)
         export_config = os.path.join( '/export{{ galaxy_server_dir }}/config', config )
         export_sample = export_config + ".docker_sample"
         shutil.copy(image_config, export_sample)

--- a/templates/export_user_files.py.j2
+++ b/templates/export_user_files.py.j2
@@ -26,10 +26,10 @@ def change_path( src ):
             subprocess.call( 'chown -R %s:%s %s' % ( os.environ['GALAXY_UID'], os.environ['GALAXY_GID'], dest ), shell=True )
         # if destination exists (e.g. continuing a previous session), remove source and symlink
         else:
-            if os.path.isdir( src ):
+            if os.path.isdir( src ) and not os.path.islink( src.rstrip('/') ):
                 shutil.rmtree( src )
             else:
-                os.unlink( src )
+                os.unlink( src.rstrip('/') )
             os.symlink( dest, src.rstrip('/') )
 
 

--- a/templates/export_user_files.py.j2
+++ b/templates/export_user_files.py.j2
@@ -43,7 +43,7 @@ if __name__ == "__main__":
     """
     if os.path.exists( '/export/.distribution_config/' ):
         shutil.rmtree( '/export/.distribution_config/' )
-    shutil.copytree( '/galaxy-central/config/', '/export/.distribution_config/' )
+    shutil.copytree( '{{ galaxy_server_dir }}/config/', '/export/.distribution_config/' )
 
 
     # Copy all files starting with "welcome"
@@ -54,11 +54,11 @@ if __name__ == "__main__":
             image_file = os.path.join('/etc/galaxy/web/', filename)
             shutil.copy(export_file, image_file)
 
-    if not os.path.exists( '/export/galaxy-central/' ):
-        os.makedirs("/export/galaxy-central/")
-        os.chown( "/export/galaxy-central/", int(os.environ['GALAXY_UID']), int(os.environ['GALAXY_GID']) )
+    if not os.path.exists( '/export{{ galaxy_server_dir }}/' ):
+        os.makedirs("/export{{ galaxy_server_dir }}/")
+        os.chown( "/export{{ galaxy_server_dir }}/", int(os.environ['GALAXY_UID']), int(os.environ['GALAXY_GID']) )
 
-    change_path('/galaxy-central/config/')
+    change_path('{{ galaxy_server_dir }}/config/')
 
     # copy image defaults to config/<file>.docker_sample to base derivatives on,
     # and if there is a realized version of these files in the export directory
@@ -66,16 +66,16 @@ if __name__ == "__main__":
     # deployer can update and reload Galaxy and changes will be reflected.
     for config in [ 'galaxy.ini', 'job_conf.xml' ]:
         image_config = os.path.join('/etc/galaxy/', config)
-        export_config = os.path.join( '/export/galaxy-central/config', config )
+        export_config = os.path.join( '/export{{ galaxy_server_dir }}/config', config )
         export_sample = export_config + ".docker_sample"
         shutil.copy(image_config, export_sample)
         if os.path.exists(export_config):
             subprocess.call('ln -s -f %s %s' % (export_config, image_config), shell=True)
 
-    change_path('/galaxy-central/integrated_tool_panel.xml')
-    change_path('/galaxy-central/display_applications/')
-    change_path('/galaxy-central/tool_deps/')
-    change_path('/galaxy-central/tool-data/')
+    change_path('{{ galaxy_server_dir }}/integrated_tool_panel.xml')
+    change_path('{{ galaxy_server_dir }}/display_applications/')
+    change_path('{{ galaxy_server_dir }}/tool_deps/')
+    change_path('{{ galaxy_server_dir }}/tool-data/')
     change_path('/shed_tools/')
     
     if os.path.exists('/export/reports_htpasswd'):

--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -9,7 +9,7 @@ ansible localhost -m ini_file -a "dest=/etc/supervisor/conf.d/galaxy.conf sectio
 
 cd {{ galaxy_server_dir }}
 . {{ galaxy_venv_dir }}/bin/activate
-{% if use_docker|bool %}
+{% if galaxy_extras_config_docker|bool %}
 umount /var/lib/docker
 {% endif %}
 
@@ -83,7 +83,7 @@ then
 fi
 {% endif %}
 
-{% if use_slurm|bool %}
+{% if galaxy_extras_config_slurm|bool %}
 # Copy or link the slurm/munge config files
 if [ -e /export/slurm.conf ]
 then
@@ -129,36 +129,35 @@ function start_supervisor {
     fi
     {% endif %}
 
-
-    {% if supervisor_manage_slurm %}
-        if [[ $NONUSE != *"slurmctld"* ]]
-        then
-            echo "Starting slurmctld"
-            supervisorctl start slurmctld
-        fi
-        if [[ $NONUSE != *"slurmd"* ]]
-        then
-            echo "Starting slurmd"
-            supervisorctl start slurmd
-        fi
-        supervisorctl start munge
-
-    {% else %}
-      {% if use_slurm|bool %}
-        if [[ $NONUSE != *"slurmctld"* ]]
-        then
-            echo "Starting slurmctld"
-            /usr/sbin/slurmctld -L {{ slurm_log_dir }}/slurmctld.log
-        fi
-        if [[ $NONUSE != *"slurmd"* ]]
-        then
-            echo "Starting slurmd"
-            /usr/sbin/slurmd -L {{ slurm_log_dir }}/slurmd.log
-        fi
-
-        # We need to run munged regardless
-        mkdir -p /var/run/munge && /usr/sbin/munged -f
-      {% endif %}
+    {% if galaxy_extras_config_slurm|bool %}
+       {% if supervisor_manage_slurm|bool %}
+           if [[ $NONUSE != *"slurmctld"* ]]
+           then
+               echo "Starting slurmctld"
+               supervisorctl start slurmctld
+           fi
+           if [[ $NONUSE != *"slurmd"* ]]
+           then
+               echo "Starting slurmd"
+               supervisorctl start slurmd
+           fi
+           supervisorctl start munge
+   
+       {% else %}
+           if [[ $NONUSE != *"slurmctld"* ]]
+           then
+               echo "Starting slurmctld"
+               /usr/sbin/slurmctld -L {{ slurm_log_dir }}/slurmctld.log
+           fi
+           if [[ $NONUSE != *"slurmd"* ]]
+           then
+               echo "Starting slurmd"
+               /usr/sbin/slurmd -L {{ slurm_log_dir }}/slurmd.log
+           fi
+   
+           # We need to run munged regardless
+           mkdir -p /var/run/munge && /usr/sbin/munged -f
+       {% endif %}
     {% endif %}
 }
 

--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -9,7 +9,7 @@ ansible localhost -m ini_file -a "dest=/etc/supervisor/conf.d/galaxy.conf sectio
 
 cd {{ galaxy_server_dir }}
 . {{ galaxy_venv_dir }}/bin/activate
-{% if supervisor_manage_docker|bool %}
+{% if use_docker|bool %}
 umount /var/lib/docker
 {% endif %}
 

--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -13,7 +13,7 @@ cd {{ galaxy_server_dir }}
 umount /var/lib/docker
 {% endif %}
 
-{% if startup_export_user_files is defined and startup_export_user_files %}
+{% if startup_export_user_files is defined and startup_export_user_files|bool %}
 # If /export/ is mounted, export_user_files file moving all data to /export/
 # symlinks will point from the original location to the new path under /export/
 # If /export/ is not given, nothing will happen in that step
@@ -47,7 +47,7 @@ if [ -e /export/postgresql/ ];
 fi
 
 
-{% if galaxy_extras_config_condor %}
+{% if galaxy_extras_config_condor|bool %}
 if [ "x$ENABLE_CONDOR" != "x" ]
 then
     echo "Enabling Condor"
@@ -60,7 +60,7 @@ fi
 {% endif %}
 
 
-{% if startup_chown_on_directory is defined and startup_chown_on_directory %}
+{% if startup_chown_on_directory is defined and startup_chown_on_directory|bool %}
 if [ -e {{ startup_chown_on_directory }}  ];
 then
     old_uid=`stat -c '%u' "{{ galaxy_home_dir }}"`
@@ -107,21 +107,21 @@ fi
 function start_supervisor {
     supervisord -c /etc/supervisor/supervisord.conf
     sleep 5
-    {% if supervisor_manage_proftp %}
+    {% if supervisor_manage_proftp|bool %}
     if [[ $NONUSE != *"proftp"* ]]
     then
         echo "Starting ProFTP"
         supervisorctl start proftpd
     fi
     {% endif %}
-    {% if supervisor_manage_reports %}
+    {% if supervisor_manage_reports|bool %}
     if [[ $NONUSE != *"reports"* ]]
     then
         echo "Starting Galaxy reports webapp"
         supervisorctl start reports
     fi
     {% endif %}
-    {% if supervisor_manage_ie_proxy %}
+    {% if supervisor_manage_ie_proxy|bool %}
     if [[ $NONUSE != *"nodejs"* ]]
     then
         echo "Starting nodejs"

--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -9,7 +9,9 @@ ansible localhost -m ini_file -a "dest=/etc/supervisor/conf.d/galaxy.conf sectio
 
 cd {{ galaxy_server_dir }}
 . {{ galaxy_venv_dir }}/bin/activate
+{% if supervisor_manage_docker|bool %}
 umount /var/lib/docker
+{% endif %}
 
 {% if startup_export_user_files is defined and startup_export_user_files %}
 # If /export/ is mounted, export_user_files file moving all data to /export/

--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -83,7 +83,7 @@ then
 fi
 {% endif %}
 
-
+{% if supervisor_manage_slurm|bool %}
 # Copy or link the slurm/munge config files
 if [ -e /export/slurm.conf ]
 then
@@ -94,13 +94,14 @@ else
     # Use absolute path to python so virtualenv is not used.
     /usr/bin/python /usr/sbin/configure_slurm.py
 fi
+
 if [ -e /export/munge.key ]
 then
     rm -f /etc/munge/munge.key
     ln -s /export/munge.key /etc/munge/munge.key
     chmod 400 /export/munge.key
 fi
-
+{% endif %}
 # $NONUSE can be set to include proftp, reports or nodejs
 # if included we will _not_ start these services.
 function start_supervisor {

--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -83,7 +83,7 @@ then
 fi
 {% endif %}
 
-{% if supervisor_manage_slurm|bool %}
+{% if use_slurm|bool %}
 # Copy or link the slurm/munge config files
 if [ -e /export/slurm.conf ]
 then
@@ -144,6 +144,7 @@ function start_supervisor {
         supervisorctl start munge
 
     {% else %}
+      {% if use_slurm|bool %}
         if [[ $NONUSE != *"slurmctld"* ]]
         then
             echo "Starting slurmctld"
@@ -157,7 +158,7 @@ function start_supervisor {
 
         # We need to run munged regardless
         mkdir -p /var/run/munge && /usr/sbin/munged -f
-
+      {% endif %}
     {% endif %}
 }
 


### PR DESCRIPTION
- Introduces two ansible variables, `use_slurm` and `use_docker` (and uses them), as there are places in the templates that are executed regardless of whether `galaxy_extras_config_[slurm|docker]` and `supervisor_manage_[slurm|docker]` were true or false. In our use case we don't need neither slurm nor docker. But please let me know if the role of these variables is covered well by `galaxy_extras_config..` and `supervisor_manage..` and I'll switch the parts were I added control by the new variables to the original ones.
- Fixes a border case in which a directory being evaluated was a symlink.
- Replaces hard coded `/galaxy-central` and `/etc/galaxy` by the adequate ansible variables.
