### PR TITLE
remove psutil

### DIFF
--- a/tasks/pbs.yml
+++ b/tasks/pbs.yml
@@ -3,7 +3,6 @@
   with_items:
     - torque-client
     - pbs-drmaa-dev
-    - python-psutil
   when: galaxy_extras_install_packages
 
 - name: Check if Galaxy uses eggs or wheels

--- a/tasks/slurm.yml
+++ b/tasks/slurm.yml
@@ -10,7 +10,6 @@
     - munge
     - slurm-llnl
     - slurm-drmaa-dev
-    - python-psutil
   when: galaxy_extras_install_packages
 
 - name: Install SLURM system packages

--- a/tasks/slurm.yml
+++ b/tasks/slurm.yml
@@ -10,6 +10,7 @@
     - munge
     - slurm-llnl
     - slurm-drmaa-dev
+    - python-psutil
   when: galaxy_extras_install_packages
 
 - name: Install SLURM system packages


### PR DESCRIPTION
psutil is nowadays in Galaxy and will be installed via Galaxy wheels. So we can remove it from this role. https://github.com/galaxyproject/galaxy/blob/431c7707b5f5d9f424267b8e059c2e2d42deb9df/lib/galaxy/dependencies/requirements.txt#L48