### PR TITLE
Make ftp and sftp stand side by side, instead of replacing ftp with sftp

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -150,6 +150,7 @@ proftpd_passive_port_low: 30000
 proftpd_passive_port_high: 40000
 # Set proftpd_use_sftp to true to use sftp instead of ftp
 proftpd_use_sftp: false
+proftpd_sftp_port: 8022
 # Set masquearade to true if host is NAT'ed.
 proftpd_nat_masquerade: false
 # proftpd_masquerade_address refefers to the ip that clients use to establish an ftp connection.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -150,7 +150,7 @@ proftpd_passive_port_low: 30000
 proftpd_passive_port_high: 40000
 # Set proftpd_use_sftp to true to use sftp instead of ftp
 proftpd_use_sftp: false
-proftpd_sftp_port: 8022
+proftpd_sftp_port: 22
 # Set masquearade to true if host is NAT'ed.
 proftpd_nat_masquerade: false
 # proftpd_masquerade_address refefers to the ip that clients use to establish an ftp connection.

--- a/templates/proftpd.conf.j2
+++ b/templates/proftpd.conf.j2
@@ -23,10 +23,7 @@ PassivePorts                    {{ proftpd_passive_port_low }} {{ proftpd_passiv
     SFTPEngine                              on
     SFTPLog                                 none
     SFTPHostKey                     /etc/proftpd/ssh_host_keys/rsa
-    SFTPHostKey                     /etc/proftpd/ssh_host_keys/dsa
-    SFTPAuthorizedUserKeys  file:../etc/ssh/authorized_keys
     SFTPCompression                 delayed
-    MaxLoginAttempts                6
 </VirtualHost>
 {% endif %}
 

--- a/templates/proftpd.conf.j2
+++ b/templates/proftpd.conf.j2
@@ -23,6 +23,7 @@ PassivePorts                    {{ proftpd_passive_port_low }} {{ proftpd_passiv
     SFTPEngine                              on
     SFTPLog                                 none
     SFTPHostKey                     /etc/proftpd/ssh_host_keys/rsa
+    SFTPHostKey                     /etc/proftpd/ssh_host_keys/dsa		
     SFTPCompression                 delayed
 </VirtualHost>
 {% endif %}

--- a/templates/proftpd.conf.j2
+++ b/templates/proftpd.conf.j2
@@ -19,7 +19,7 @@ PassivePorts                    {{ proftpd_passive_port_low }} {{ proftpd_passiv
 
 {% if proftpd_use_sftp %}
 <VirtualHost 0.0.0.0>
-    Port                                    2222
+    Port                                    {{ proftpd_sftp_port }}
     SFTPEngine                              on
     SFTPLog                                 none
     SFTPHostKey                     /etc/proftpd/ssh_host_keys/rsa

--- a/templates/proftpd.conf.j2
+++ b/templates/proftpd.conf.j2
@@ -18,14 +18,17 @@ Group                           nogroup
 PassivePorts                    {{ proftpd_passive_port_low }} {{ proftpd_passive_port_high }}
 
 {% if proftpd_use_sftp %}
-SFTPEngine                      on
-
-# Configure both the RSA and DSA host keys, using the same host key files that OpenSSH uses.
-SFTPHostKey                     /etc/proftpd/ssh_host_keys/rsa
-SFTPHostKey                     /etc/proftpd/ssh_host_keys/dsa
-SFTPCompression                 delayed
+<VirtualHost 0.0.0.0>
+    Port                                    2222
+    SFTPEngine                              on
+    SFTPLog                                 none
+    SFTPHostKey                     /etc/proftpd/ssh_host_keys/rsa
+    SFTPHostKey                     /etc/proftpd/ssh_host_keys/dsa
+    SFTPAuthorizedUserKeys  file:../etc/ssh/authorized_keys
+    SFTPCompression                 delayed
+    MaxLoginAttempts                6
+</VirtualHost>
 {% endif %}
-
 
 {% if proftpd_nat_masquerade %}
 # If your host was NATted, this option is useful in order to

--- a/templates/proftpd.conf.j2
+++ b/templates/proftpd.conf.j2
@@ -19,12 +19,12 @@ PassivePorts                    {{ proftpd_passive_port_low }} {{ proftpd_passiv
 
 {% if proftpd_use_sftp %}
 <VirtualHost 0.0.0.0>
-    Port                                    {{ proftpd_sftp_port }}
-    SFTPEngine                              on
-    SFTPLog                                 none
-    SFTPHostKey                     /etc/proftpd/ssh_host_keys/rsa
-    SFTPHostKey                     /etc/proftpd/ssh_host_keys/dsa		
-    SFTPCompression                 delayed
+    Port                        {{ proftpd_sftp_port }}
+    SFTPEngine                  on
+    SFTPLog                     none
+    SFTPHostKey                 /etc/proftpd/ssh_host_keys/rsa
+    SFTPHostKey                 /etc/proftpd/ssh_host_keys/dsa
+    SFTPCompression             delayed
 </VirtualHost>
 {% endif %}
 


### PR DESCRIPTION
I've not yet taken the step of removing the flag entirely, which would turn on sftp and ftp on together by default. I can't really imagine anyone *not* wanting the option of sftp, but maybe it makes sense to keep the flag. Let me know @martenson @mvdbeek @bgruening @jmchilton 