### PR TITLE
Rabbitmq

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,7 @@ galaxy_extras_config_ie_proxy: true
 galaxy_extras_config_neo4j_ie: false  # Configure routes for the Neo4j Interactive Environment
 galaxy_extras_config_scripts: true
 galaxy_extras_config_startup: true
+galaxy_extras_config_rabbitmq: false
 galaxy_extras_galaxy_destination_default: slurm_cluster
 
 # set the FQDN for the pbs server, only used when galaxy_extras_config_pbs: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,5 +30,8 @@
 - include: galaxy_scripts.yml
   when: galaxy_extras_config_scripts
 
+- include: rabbitmq.yml
+  when: galaxy_extras_config_rabbitmq
+
 - include: startup.yml
   when: galaxy_extras_config_startup

--- a/tasks/rabbitmq.yml
+++ b/tasks/rabbitmq.yml
@@ -1,0 +1,2 @@
+- name: Copy startup script for rabbitmq
+  template: src=rabbitmq.sh.j2 dest=/usr/local/bin/rabbitmq.sh

--- a/templates/rabbitmq.sh.j2
+++ b/templates/rabbitmq.sh.j2
@@ -1,15 +1,20 @@
+#!/bin/sh
 # call "rabbitmqctl stop" when exiting
 # taken from https://gist.github.com/caioariede/342a583f75467509ad42
+mkdir -p /var/run/rabbitmq && chown rabbitmq:rabbitmq /var/run/rabbitmq && chmod 755 /var/run/rabbitmq
+RABBITMQ_ENV=/usr/lib/rabbitmq/bin/rabbitmq-env
+RABBITMQ_SCRIPTS_DIR=$(dirname "$RABBITMQ_ENV")
+. /usr/lib/rabbitmq/bin/rabbitmq-env
 trap "{ echo Stopping rabbitmq; rabbitmqctl stop; exit 0; }" TERM
 
 echo Starting rabbitmq
-sudo -u rabbitmq rabbitmq-server &
+rabbitmq-server &
 
 # from docs: When Bash receives a signal for which a
 # trap has been set while waiting for a command to
 # complete, the trap will not be executed until the
 # command completes.
-# 
+#
 # This is why we use & and wait here. Idea taken from:
 # http://veithen.github.io/2014/11/16/sigterm-propagation.html
 PID=$!

--- a/templates/rabbitmq.sh.j2
+++ b/templates/rabbitmq.sh.j2
@@ -1,0 +1,16 @@
+# call "rabbitmqctl stop" when exiting
+# taken from https://gist.github.com/caioariede/342a583f75467509ad42
+trap "{ echo Stopping rabbitmq; rabbitmqctl stop; exit 0; }" TERM
+
+echo Starting rabbitmq
+sudo -u rabbitmq rabbitmq-server &
+
+# from docs: When Bash receives a signal for which a
+# trap has been set while waiting for a command to
+# complete, the trap will not be executed until the
+# command completes.
+# 
+# This is why we use & and wait here. Idea taken from:
+# http://veithen.github.io/2014/11/16/sigterm-propagation.html
+PID=$!
+wait $PID

--- a/templates/supervisor.conf.j2
+++ b/templates/supervisor.conf.j2
@@ -188,6 +188,17 @@ startsecs       = 5
 redirect_stderr = true
 {% endif %}
 
+{% if galaxy_extras_config_rabbitmq|bool %}
+[program:rabbitmq]
+command=/bin/sh /usr/local/sbin/rabbitmq.sh
+user=root
+autostart=true
+autorestart=true
+environment=
+  HOME="/var/lib/rabbitmq/",
+  RABBITMQ_PID_FILE="/var/run/rabbitmq/pid"
+{% endif %}
+
 [group:galaxy]
 {% if supervisor_manage_ie_proxy|bool %}
 programs = handler, galaxy_web, galaxy_nodejs_proxy

--- a/templates/supervisor.conf.j2
+++ b/templates/supervisor.conf.j2
@@ -190,13 +190,10 @@ redirect_stderr = true
 
 {% if galaxy_extras_config_rabbitmq|bool %}
 [program:rabbitmq]
-command=/bin/sh /usr/local/sbin/rabbitmq.sh
-user=root
-autostart=true
-autorestart=true
-environment=
-  HOME="/var/lib/rabbitmq/",
-  RABBITMQ_PID_FILE="/var/run/rabbitmq/pid"
+command         = /bin/sh /usr/local/bin/rabbitmq.sh
+user            = root
+autostart       = true
+autorestart     = true
 {% endif %}
 
 [group:galaxy]


### PR DESCRIPTION
This goes with https://github.com/galaxyproject/ansible-galaxy-os/pull/20.
TL;DR with rabbitmq we can automatically reload tool data tables after data managers have run (and other things).