### PR TITLE
Make sure the Galaxy log dir exists.

### DIFF
--- a/tasks/galaxy_metrics.yml
+++ b/tasks/galaxy_metrics.yml
@@ -1,4 +1,4 @@
 # TODO: I believe job_metrics_conf.xml can just be specified as YML now (at
 # least it can in pulsar) so that should be a separate option.
 - name: "Setup job metrics"
-  template: src=job_metrics_conf.xml.j2 dest={{galaxy_job_metrics_conf_path}}
+  template: src=job_metrics_conf.xml.j2 dest={{galaxy_job_metrics_conf_path}} owner={{ galaxy_user_name }} group={{ galaxy_user_name }}

--- a/tasks/galaxy_root.yml
+++ b/tasks/galaxy_root.yml
@@ -8,3 +8,6 @@
   pip: name=watchdog virtualenv={{ galaxy_venv_dir }} virtualenv_command="{{ pip_virtualenv_command | default( 'virtualenv' ) }}"
   become: True
   become_user: "{{ galaxy_user_name }}"
+
+- name: Ensure galaxy_log dir exists
+  file: path={{ galaxy_log_dir }} state=directory owner={{ galaxy_user_name }} group={{ galaxy_user_name }}

--- a/tasks/pbs.yml
+++ b/tasks/pbs.yml
@@ -26,7 +26,7 @@
   when: requirements_txt.stat.exists
 
 - name: "Install Galaxy job conf"
-  template: src=job_conf.xml.j2 dest={{galaxy_job_conf_path}}
+  template: src=job_conf.xml.j2 dest={{galaxy_job_conf_path}} owner={{ galaxy_user_name }} group={{ galaxy_user_name }}
   tags: galaxy_extras_job_conf
 
 - name: "Set PBS/torque server name"

--- a/tasks/slurm.yml
+++ b/tasks/slurm.yml
@@ -16,13 +16,13 @@
 - name: Install SLURM system packages
   apt: pkg={{ item }} state={{ galaxy_extras_apt_package_state }}
   with_items:
-    - slurm-llnl-torque 
+    - slurm-llnl-torque
   when: galaxy_extras_install_packages|bool and ansible_distribution_version <= "15.04"
 
 - name: Install SLURM system packages
   apt: pkg={{ item }} state={{ galaxy_extras_apt_package_state }}
   with_items:
-    - slurm-wlm-torque 
+    - slurm-wlm-torque
   when: galaxy_extras_install_packages|bool and ansible_distribution_version >= "15.04"
 
 - name: Create Munge Key
@@ -64,5 +64,5 @@
   when: requirements_txt.stat.exists
 
 - name: "Install Galaxy job conf"
-  template: src=job_conf.xml.j2 dest={{galaxy_job_conf_path}}
+  template: src=job_conf.xml.j2 dest={{galaxy_job_conf_path}} owner={{ galaxy_user_name }} group={{ galaxy_user_name }}
   tags: galaxy_extras_job_conf


### PR DESCRIPTION
Variable `galaxy_log_dir` carries a default value and it is used in a number of tasks so ensure the given dir exists.