### PR TITLE
Add role meta folder

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,15 @@
+---
+galaxy_info:
+  author: The Galaxy Project
+  description: Configure assorted compontents for the Galaxy application.
+  company: The Galaxy Project
+  license: AFL v3.0
+  min_ansible_version: 2.0.0.1
+  platforms:
+  - name: Ubuntu
+    versions:
+    - trusty
+  categories:
+  - system
+dependencies: []
+allow_duplicates: yes


### PR DESCRIPTION
This allows the role to be installed via `ansible-galaxy` command, which can be desirable in general and needed by https://github.com/ARTbio/GalaxyKickStart/issues/186.