### PR TITLE
Tags and startup.sh

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,13 +10,19 @@
 
 - include: nginx.yml
   when: galaxy_extras_config_nginx
-  tags: nginx_config
+  tags:
+   - nginx_config
+   - nginx
 
 - include: proftpd.yml
   when: galaxy_extras_config_proftpd
+  tags:
+   - proftpd
 
 - include: slurm.yml
   when: galaxy_extras_config_slurm
+  tags:
+   - slurm
 
 - include: pbs.yml
   when: galaxy_extras_config_pbs

--- a/tasks/proftpd.yml
+++ b/tasks/proftpd.yml
@@ -5,6 +5,8 @@
     - proftpd
     - proftpd-mod-pgsql
   when: galaxy_extras_install_packages
+  tags:
+    - proftpd_apt
 
 - name: Create Galaxy configuration file
   template: src=proftpd.conf.j2 dest={{ proftpd_conf_path }}
@@ -27,6 +29,8 @@
 - name: Install OpenSSH client package
   apt: pkg=openssh-client
   when: proftpd_use_sftp
+  tags:
+   - proftpd_apt
 
 - name: Create /etc/proftpd/ssh_host_keys/ directory
   file: path=/etc/proftpd/ssh_host_keys/ state=directory

--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -271,3 +271,9 @@ if [ "x$DISABLE_REPORTS_AUTH" != "x" ]
         echo "Disable Galaxy reports authentification "
         rm /etc/nginx/htpasswd
 fi
+
+# In case the user wants the default admin to be created, do so.
+if [ "x$GALAXY_DEFAULT_ADMIN_USER" != "x" ]
+    then
+    python /usr/local/bin/create_galaxy_user.py --user $GALAXY_DEFAULT_ADMIN_USER --password $GALAXY_DEFAULT_ADMIN_PASSWORD -c $GALAXY_CONFIG_FILE --key $GALAXY_DEFAULT_ADMIN_KEY
+fi


### PR DESCRIPTION
Added tags for nginx, proftpd, slurm.
startup.sh always creates the admin user in case it doesn't exist.