### PR TITLE
Change galaxy_docker_volumes_from to ""

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,7 +51,7 @@ galaxy_extras_docker_storage_backend: aufs
 
 galaxy_docker_enabled: false
 galaxy_docker_sudo: false
-galaxy_docker_volumes_from: galaxy
+galaxy_docker_volumes_from: ""
 galaxy_docker_volumes : "$defaults"
 
 # Point at the existing Galaxy configuration.


### PR DESCRIPTION
@jmchilton do you know why this was set to `galaxy` there is no data-volume called galaxy available, isn't it.