### PR TITLE
Add remote_user header if received from another proxy

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -116,6 +116,7 @@ nginx_ide_location: "{{ nginx_prefix_location }}/ide"
 nginx_use_passwords: False
 nginx_htpasswds:
   - "admin:WiBKbsJTSQ8dc"
+nginx_use_remote_header: False
 
 ## Development Box Configuration
 # Configure nginx to setup a proxy to an IDE.

--- a/templates/nginx_galaxy_web.conf.j2
+++ b/templates/nginx_galaxy_web.conf.j2
@@ -6,7 +6,8 @@ location {{ nginx_galaxy_location }}/ {
 {% if galaxy_admin_user is defined and galaxy_admin_user %}
     # hard-code a fixed user to pass to Galaxy to auto-login
 	proxy_set_header REMOTE_USER '{{ galaxy_admin_user }}';
-{% else %}
+{% endif %}
+{% if nginx_use_remote_header %}
     # forward the remote_user header in case it is set by a previous proxy
     if ($remote_user) {
         proxy_set_header REMOTE_USER $remote_user;

--- a/templates/nginx_galaxy_web.conf.j2
+++ b/templates/nginx_galaxy_web.conf.j2
@@ -2,9 +2,14 @@
 location {{ nginx_galaxy_location }}/ {
 	proxy_pass http://galaxy_web_app;
 	proxy_set_header X-Forwarded-Host $host;
-	proxy_set_header X-Forwarded-For  $proxy_add_x_forwarded_for;     
+	proxy_set_header X-Forwarded-For  $proxy_add_x_forwarded_for;
 {% if galaxy_admin_user is defined and galaxy_admin_user %}
     # hard-code a fixed user to pass to Galaxy to auto-login
 	proxy_set_header REMOTE_USER '{{ galaxy_admin_user }}';
+{% else %}
+    # forward the remote_user header in case it is set by a previous proxy
+    if ($remote_user) {
+        proxy_set_header REMOTE_USER $remote_user;
+    }
 {% endif %}
 }

--- a/templates/nginx_uwsgi.conf.j2
+++ b/templates/nginx_uwsgi.conf.j2
@@ -5,5 +5,10 @@ location {{ nginx_galaxy_location }}/ {
 {% if galaxy_admin_user is defined and galaxy_admin_user %}
     # hard-code a fixed user to pass to Galaxy to auto-login
     uwsgi_param HTTP_REMOTE_USER '{{ galaxy_admin_user }}';
+{% else %}
+    # forward the remote_user header in case it is set by a previous proxy
+    if ($remote_user) {
+        uwsgi_param HTTP_REMOTE_USER $remote_user;
+    }
 {% endif %}
 }

--- a/templates/nginx_uwsgi.conf.j2
+++ b/templates/nginx_uwsgi.conf.j2
@@ -8,8 +8,6 @@ location {{ nginx_galaxy_location }}/ {
 {% endif %}
 {% if nginx_use_remote_header %}
     # forward the remote_user header in case it is set by a previous proxy
-    if ($remote_user) {
-        uwsgi_param HTTP_REMOTE_USER $remote_user;
-    }
+    uwsgi_param HTTP_REMOTE_USER $remote_user if_not_empty;
 {% endif %}
 }

--- a/templates/nginx_uwsgi.conf.j2
+++ b/templates/nginx_uwsgi.conf.j2
@@ -5,7 +5,8 @@ location {{ nginx_galaxy_location }}/ {
 {% if galaxy_admin_user is defined and galaxy_admin_user %}
     # hard-code a fixed user to pass to Galaxy to auto-login
     uwsgi_param HTTP_REMOTE_USER '{{ galaxy_admin_user }}';
-{% else %}
+{% endif %}
+{% if nginx_use_remote_header %}
     # forward the remote_user header in case it is set by a previous proxy
     if ($remote_user) {
         uwsgi_param HTTP_REMOTE_USER $remote_user;


### PR DESCRIPTION
Hej,
I needed to add these to make the authentication work on my setup which looks like this:

The Internet --> nginx proxy doing auth with ldap module, filling a REMOTE_USER header --> nginx embedded in docker-galaxy-stable