### PR TITLE
Create /.galaxy_save file and check it.

### DIFF
--- a/templates/export_user_files.py.j2
+++ b/templates/export_user_files.py.j2
@@ -50,8 +50,7 @@ if __name__ == "__main__":
         is aborted.
     """
     if os.path.exists( '/.galaxy_save' )
-        print("It is already setup. So we do nothing.")
-        sys.exit(0)
+        sys.exit("It is already setup. So we do nothing.")
     galaxy_root_dir = os.environ.get('GALAXY_ROOT', '/galaxy-central/')
 
     galaxy_distrib_paths = {'/galaxy-central/config/': '/export/.distribution_config',

--- a/templates/export_user_files.py.j2
+++ b/templates/export_user_files.py.j2
@@ -49,7 +49,8 @@ if __name__ == "__main__":
         If the user re-starts (with docker start) the container the file /.galaxy_save is found and the linking
         is aborted.
     """
-
+    if os.path.exists( '/.galaxy_save' )
+        sys.exit(0)
     galaxy_root_dir = os.environ.get('GALAXY_ROOT', '/galaxy-central/')
 
     galaxy_distrib_paths = {'/galaxy-central/config/': '/export/.distribution_config',
@@ -120,3 +121,6 @@ if __name__ == "__main__":
         subprocess.call('chmod -R 0755 /export/', shell=True)
         subprocess.call('chmod -R 0700 %s' % PG_DATA_DIR_HOST, shell=True)
 
+    file = open('/.galaxy_save', 'w') 
+    file.close()
+    os.chown( "/.galaxy_save", int(os.environ['GALAXY_UID']), int(os.environ['GALAXY_GID']) )

--- a/templates/export_user_files.py.j2
+++ b/templates/export_user_files.py.j2
@@ -50,6 +50,7 @@ if __name__ == "__main__":
         is aborted.
     """
     if os.path.exists( '/.galaxy_save' )
+        print "It is already setup. So we do nothing."
         sys.exit(0)
     galaxy_root_dir = os.environ.get('GALAXY_ROOT', '/galaxy-central/')
 
@@ -121,6 +122,5 @@ if __name__ == "__main__":
         subprocess.call('chmod -R 0755 /export/', shell=True)
         subprocess.call('chmod -R 0700 %s' % PG_DATA_DIR_HOST, shell=True)
 
-    file = open('/.galaxy_save', 'w') 
-    file.close()
+    open('/.galaxy_save', 'w').close()
     os.chown( "/.galaxy_save", int(os.environ['GALAXY_UID']), int(os.environ['GALAXY_GID']) )

--- a/templates/export_user_files.py.j2
+++ b/templates/export_user_files.py.j2
@@ -50,7 +50,7 @@ if __name__ == "__main__":
         is aborted.
     """
     if os.path.exists( '/.galaxy_save' )
-        print "It is already setup. So we do nothing."
+        print("It is already setup. So we do nothing.")
         sys.exit(0)
     galaxy_root_dir = os.environ.get('GALAXY_ROOT', '/galaxy-central/')
 


### PR DESCRIPTION
Comment describe user re-starts with docker start and stop.
But I can't find any /.galaxy_file.

So this PullRequest create /.galaxy_file after all setup finished by this script at container start first time.
And check /.galaxy_file when this script's enter main to avoid this script run twice.