### PR TITLE
Configure proxy prefix

### DIFF
--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -7,11 +7,12 @@
     dest={{ item.dest }}
     owner=root group=root mode=0600
   with_items:
-    - { src: 'htpasswd.j2',               dest: '/etc/nginx/htpasswd' }
-    - { src: 'nginx_ide.conf.j2',         dest: '{{ nginx_conf_directory }}/ide.conf' }
-    - { src: 'nginx_galaxy_web.conf.j2',  dest: '{{ nginx_conf_directory }}/galaxy_web.conf' }
-    - { src: 'nginx_uwsgi.conf.j2',       dest: '{{ nginx_conf_directory }}/uwsgi.conf' }
-    - { src: 'nginx.conf.j2',             dest: '{{ nginx_conf_path }}' }
+    - { src: 'htpasswd.j2',                 dest: '/etc/nginx/htpasswd' }
+    - { src: 'nginx_ide.conf.j2',           dest: '{{ nginx_conf_directory }}/ide.conf' }
+    - { src: 'nginx_galaxy_web.conf.j2',    dest: '{{ nginx_conf_directory }}/galaxy_web.conf' }
+    - { src: 'nginx_uwsgi.conf.j2',         dest: '{{ nginx_conf_directory }}/uwsgi.conf' }
+    - { src: 'nginx_reports_auth.conf.j2',  dest: '{{ nginx_conf_directory }}/reports_auth.conf.source' }
+    - { src: 'nginx.conf.j2',               dest: '{{ nginx_conf_path }}' }
   notify: restart nginx
   tags:
     - https

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -50,17 +50,10 @@ http {
 
 {% if nginx_proxy_reports %}
         # enable reports under :80/reports/
-        # if the file /etc/nginx/htpasswd exists authentification is enabled
-        location {{ nginx_reports_location }} {
-            set $auth "Galaxy reports are restricted. Please contact your administrator.";
-
-            if (!-f /etc/nginx/htpasswd) {
-                set $auth off;
-            }
-
-            auth_basic $auth;
-            auth_basic_user_file htpasswd;
-            proxy_pass http://127.0.0.1:{{ galaxy_reports_port }};
+        location {{ nginx_reports_location }}/ {
+            # include authentification settings if enabled
+            include {{ nginx_conf_directory }}/reports_auth.conf;
+            proxy_pass http://127.0.0.1:{{ galaxy_reports_port }}/;
         }
         # serve static content for report app
         location  {{ nginx_reports_location }}/static {

--- a/templates/nginx_reports_auth.conf.j2
+++ b/templates/nginx_reports_auth.conf.j2
@@ -1,0 +1,4 @@
+set $auth "Galaxy reports are restricted. Please contact your administrator.";
+
+auth_basic $auth;
+auth_basic_user_file htpasswd;

--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -49,32 +49,45 @@ echo "127.0.0.1      galaxy" >> /etc/hosts
 ansible localhost -m ini_file -a "dest=/etc/supervisor/conf.d/galaxy.conf section=program:handler option=numprocs value=${GALAXY_HANDLER_NUMPROCS:-2}" &> /dev/null
 
 # Configure proxy prefix filtering
-if [ "$GALAXY_CONFIG_PROXY_PREFIX" != "/" ]
+if [ "$PROXY_PREFIX" != "/" ]
     then
-    ansible localhost -m ini_file -a "dest=${GALAXY_CONFIG_FILE} section=filter:proxy-prefix option=prefix value=${GALAXY_CONFIG_PROXY_PREFIX}" &> /dev/null
+    ansible localhost -m ini_file -a "dest=${GALAXY_CONFIG_FILE} section=filter:proxy-prefix option=prefix value=${PROXY_PREFIX}" &> /dev/null
     ansible localhost -m ini_file -a "dest=${GALAXY_CONFIG_FILE} section=app:main option=filter-with value=proxy-prefix" &> /dev/null
 
-    ansible localhost -m ini_file -a "dest=${GALAXY_CONFIG_DIR}/reports_wsgi.ini section=filter:proxy-prefix option=prefix value=${GALAXY_CONFIG_PROXY_PREFIX}/reports" &> /dev/null
+    ansible localhost -m ini_file -a "dest=${GALAXY_CONFIG_DIR}/reports_wsgi.ini section=filter:proxy-prefix option=prefix value=${PROXY_PREFIX}/reports" &> /dev/null
     ansible localhost -m ini_file -a "dest=${GALAXY_CONFIG_DIR}/reports_wsgi.ini section=app:main option=filter-with value=proxy-prefix" &> /dev/null
 
     # Fix path to html assets
-    ansible localhost -m replace -a "dest=$GALAXY_CONFIG_DIR/web/welcome.html regexp='(href=\"|\')[/\\w]*(/static)' replace='\\1${GALAXY_CONFIG_PROXY_PREFIX}\\2'" &> /dev/null
+    ansible localhost -m replace -a "dest=$GALAXY_CONFIG_DIR/web/welcome.html regexp='(href=\"|\')[/\\w]*(/static)' replace='\\1${PROXY_PREFIX}\\2'" &> /dev/null
 
     # Set some other vars based on that prefix
     if [ "x$GALAXY_CONFIG_COOKIE_PATH" == "x" ]
         then
-        export GALAXY_CONFIG_COOKIE_PATH="$GALAXY_CONFIG_PROXY_PREFIX"
+        export GALAXY_CONFIG_COOKIE_PATH="$PROXY_PREFIX"
     fi
     if [ "x$GALAXY_CONFIG_DYNAMIC_PROXY_PREFIX" == "x" ]
         then
-        export GALAXY_CONFIG_DYNAMIC_PROXY_PREFIX="$GALAXY_CONFIG_PROXY_PREFIX/gie_proxy"
+        export GALAXY_CONFIG_DYNAMIC_PROXY_PREFIX="$PROXY_PREFIX/gie_proxy"
     fi
 
     # Changed the nginx upload path (if set to default value)
     if [ "$GALAXY_CONFIG_NGINX_UPLOAD_PATH" == "/_upload" ]
         then
-            export GALAXY_CONFIG_NGINX_UPLOAD_PATH="${GALAXY_CONFIG_PROXY_PREFIX}${GALAXY_CONFIG_NGINX_UPLOAD_PATH}"
+            export GALAXY_CONFIG_NGINX_UPLOAD_PATH="${PROXY_PREFIX}${GALAXY_CONFIG_NGINX_UPLOAD_PATH}"
     fi
+fi
+
+# Disable authentication of Galaxy reports
+if [ "x$DISABLE_REPORTS_AUTH" != "x" ]
+    then
+        # disable authentification by deleting the htpasswd file
+        echo "Disable Galaxy reports authentification "
+        rm /etc/nginx/htpasswd
+        echo "" > /etc/nginx/conf.d/reports_auth.conf
+    else
+        # enable authentification by deleting the htpasswd file
+        echo "Enable Galaxy reports authentification "
+        cp /etc/nginx/conf.d/reports_auth.conf.source /etc/nginx/conf.d/reports_auth.conf
 fi
 
 cd {{ galaxy_server_dir }}
@@ -200,7 +213,7 @@ function start_supervisor {
         supervisorctl start postgresql
     fi
     {% endif %}
-    wait_for_postgres 
+    wait_for_postgres
     {% if supervisor_manage_cron|bool %}
     if [[ $NONUSE != *"cron"* ]]
     then
@@ -348,14 +361,6 @@ then
     fi
 fi
 
-# Disable authentication of Galaxy reports
-if [ "x$DISABLE_REPORTS_AUTH" != "x" ]
-    then
-        # disable authentification by deleting the htpasswd file
-        echo "Disable Galaxy reports authentification "
-        rm /etc/nginx/htpasswd
-fi
-
 # In case the user wants the default admin to be created, do so.
 if [ "x$GALAXY_DEFAULT_ADMIN_USER" != "x" ]
     then
@@ -370,4 +375,3 @@ if [ `echo ${GALAXY_LOGGING:-'no'} | tr [:upper:] [:lower:]` = "full" ]
     else
         tail -f {{ galaxy_log_dir }}/*.log
 fi
-

--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -80,12 +80,12 @@ fi
 # Disable authentication of Galaxy reports
 if [ "x$DISABLE_REPORTS_AUTH" != "x" ]
     then
-        # disable authentification by deleting the htpasswd file
+        # disable authentification
         echo "Disable Galaxy reports authentification "
         rm /etc/nginx/htpasswd
         echo "" > /etc/nginx/conf.d/reports_auth.conf
     else
-        # enable authentification by deleting the htpasswd file
+        # enable authentification
         echo "Enable Galaxy reports authentification "
         cp /etc/nginx/conf.d/reports_auth.conf.source /etc/nginx/conf.d/reports_auth.conf
 fi

--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -48,6 +48,35 @@ echo "127.0.0.1      galaxy" >> /etc/hosts
 # Set number of Galaxy handlers via GALAXY_HANDLER_NUMPROCS or default to 2
 ansible localhost -m ini_file -a "dest=/etc/supervisor/conf.d/galaxy.conf section=program:handler option=numprocs value=${GALAXY_HANDLER_NUMPROCS:-2}" &> /dev/null
 
+# Configure proxy prefix filtering
+if [ "$GALAXY_CONFIG_PROXY_PREFIX" != "/" ]
+    then
+    ansible localhost -m ini_file -a "dest=${GALAXY_CONFIG_FILE} section=filter:proxy-prefix option=prefix value=${GALAXY_CONFIG_PROXY_PREFIX}" &> /dev/null
+    ansible localhost -m ini_file -a "dest=${GALAXY_CONFIG_FILE} section=app:main option=filter-with value=proxy-prefix" &> /dev/null
+
+    ansible localhost -m ini_file -a "dest=${GALAXY_CONFIG_DIR}/reports_wsgi.ini section=filter:proxy-prefix option=prefix value=${GALAXY_CONFIG_PROXY_PREFIX}/reports" &> /dev/null
+    ansible localhost -m ini_file -a "dest=${GALAXY_CONFIG_DIR}/reports_wsgi.ini section=app:main option=filter-with value=proxy-prefix" &> /dev/null
+
+    # Fix path to html assets
+    ansible localhost -m replace -a "dest=$GALAXY_CONFIG_DIR/web/welcome.html regexp='(href=\"|\')[/\\w]*(/static)' replace='\\1${GALAXY_CONFIG_PROXY_PREFIX}\\2'" &> /dev/null
+
+    # Set some other vars based on that prefix
+    if [ "x$GALAXY_CONFIG_COOKIE_PATH" == "x" ]
+        then
+        export GALAXY_CONFIG_COOKIE_PATH="$GALAXY_CONFIG_PROXY_PREFIX"
+    fi
+    if [ "x$GALAXY_CONFIG_DYNAMIC_PROXY_PREFIX" == "x" ]
+        then
+        export GALAXY_CONFIG_DYNAMIC_PROXY_PREFIX="$GALAXY_CONFIG_PROXY_PREFIX/gie_proxy"
+    fi
+
+    # Changed the nginx upload path (if set to default value)
+    if [ "$GALAXY_CONFIG_NGINX_UPLOAD_PATH" == "/_upload" ]
+        then
+            export GALAXY_CONFIG_NGINX_UPLOAD_PATH="${GALAXY_CONFIG_PROXY_PREFIX}${GALAXY_CONFIG_NGINX_UPLOAD_PATH}"
+    fi
+fi
+
 cd {{ galaxy_server_dir }}
 . {{ galaxy_venv_dir }}/bin/activate
 umount /var/lib/docker


### PR DESCRIPTION
Hej!
I'm running galaxy dockers behind a collection of proxies, with url prefixes and it was a bit complicated to configure until now. So I'm preparing a PR for https://github.com/bgruening/docker-galaxy-stable where I introduce a new env var (GALAXY_CONFIG_PROXY_PREFIX) which will magically make all changes necessary to make all components aware of the url prefix.
The main logic is in this PR, most of it is working on my test setup, though I'll do more tests next week.
Open to any suggestions of course!
Happy easter! 🥚 🥚 🥚 