### PR TITLE
Improvements for Containerized Execution of Jobs

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,7 +22,10 @@ galaxy_extras_config_ssl_method: self-signed  # This may be 'own', 'self-signed'
 galaxy_extras_galaxy_domain: "localhost"  # This is used by letsencrypt, set it to the domain name under which galaxy can be reached
 galaxy_extras_config_startup: true
 galaxy_extras_config_rabbitmq: false
+
+# Default destination for Galaxy jobs.
 galaxy_extras_galaxy_destination_default: slurm_cluster
+galaxy_extras_galaxy_destination_docker_default: "{{ galaxy_extras_galaxy_destination_default }}"
 
 # set the FQDN for the pbs server, only used when galaxy_extras_config_pbs: true
 pbs_server_name: pbsqueue

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,9 +23,17 @@ galaxy_extras_galaxy_domain: "localhost"  # This is used by letsencrypt, set it 
 galaxy_extras_config_startup: true
 galaxy_extras_config_rabbitmq: false
 
-# Default destination for Galaxy jobs.
+# Default destination for Galaxy jobs in generated job_conf.xml - can
+# tweak this to allow for a different default for Docker-enabled tools.
 galaxy_extras_galaxy_destination_default: slurm_cluster
 galaxy_extras_galaxy_destination_docker_default: "{{ galaxy_extras_galaxy_destination_default }}"
+
+galaxy_extras_config_container_resolution: false
+container_resolution_explicit: true
+container_resolution_mulled: true
+container_resolution_cached_mulled: "{{ container_resolution_mulled }}"
+container_resolution_build_mulled: "{{ container_resolution_mulled }}"
+container_resolution_mulled_namespace: biocontainers
 
 # set the FQDN for the pbs server, only used when galaxy_extras_config_pbs: true
 pbs_server_name: pbsqueue
@@ -63,6 +71,7 @@ galaxy_docker_volumes : "$defaults"
 # Point at the existing Galaxy configuration.
 galaxy_server_dir: "/galaxy-central"
 galaxy_job_conf_path: "{{ galaxy_server_dir }}/config/job_conf.xml"
+galaxy_container_resolvers_conf_path: "{{ galaxy_server_dir }}/config/container_resolvers_conf.xml"
 galaxy_job_metrics_conf_path: "{{ galaxy_server_dir }}/config/job_metrics_conf.xml"
 galaxy_user_name: "galaxy"
 galaxy_home_dir: "/home/{{ galaxy_user_name }}"

--- a/tasks/slurm.yml
+++ b/tasks/slurm.yml
@@ -63,6 +63,12 @@
     VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
   when: requirements_txt.stat.exists
 
+# TODO: Move the following two out of this file since it is no longer SLURM specific.
 - name: "Install Galaxy job conf"
   template: src=job_conf.xml.j2 dest={{galaxy_job_conf_path}} owner={{ galaxy_user_name }} group={{ galaxy_user_name }}
+  tags: galaxy_extras_job_conf
+
+- name: "Install Galaxy container resolution configuration"
+  template: src=container_resolvers_conf.xml.j2 dest={{galaxy_container_resolvers_conf_path}} owner={{ galaxy_user_name }} group={{ galaxy_user_name }}
+  when: galaxy_extras_config_container_resolution|bool
   tags: galaxy_extras_job_conf

--- a/templates/container_resolvers_conf.xml.j2
+++ b/templates/container_resolvers_conf.xml.j2
@@ -1,0 +1,14 @@
+<container_resolvers>
+  {% if container_resolution_explicit %}
+  <explicit />
+  {% endif %}
+  {% if container_resolution_cached_mulled %}
+  <cached_mulled />
+  {% endif %}
+  {% if container_resolution_mulled %}
+  <mulled namespace="{{ container_resolution_mulled_namespace }}" />
+  {% endif %}
+  {% if container_resolution_build_mulled %}
+  <build_mulled namespace="local" />
+  {% endif %}
+</container_resolvers>

--- a/templates/job_conf.xml.j2
+++ b/templates/job_conf.xml.j2
@@ -23,6 +23,7 @@
             <param id="k8s_persistent_volume_claim_mount_path">/export</param>
         </plugin>
 {% endif %}
+        <plugin id="local" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner"/>
     </plugins>
     <!-- The default handler can be changed by specifying the GALAXY_HANDLERS_DEFAULT environment variable. -->
     <handlers default_from_environ="GALAXY_HANDLERS_DEFAULT" default="handlers">
@@ -36,6 +37,16 @@
     </handlers>
     <!-- The default destination can be changed by specifying the GALAXY_DESTINATIONS_DEFAULT environment variable. -->
     <destinations default_from_environ="GALAXY_DESTINATIONS_DEFAULT" default="{{ galaxy_extras_galaxy_destination_default }}">
+        <destination id="docker_dispatch" runner="dynamic">
+            <!-- Allow different default destinations based on whether the tool
+                 supports Docker or not. -->
+            <param id="type">docker_dispatch</param>
+            <param id="docker_destination_id" from_environ="GALAXY_DESTINATIONS_DOCKER_DEFAULT">{{ galaxy_extras_galaxy_destination_docker_default }}</param>
+            <param id="default_destination_id" from_environ="GALAXY_DESTINATIONS_NO_DOCKER_DEFAULT">{{ galaxy_extras_galaxy_destination_default }}</param>
+        </destination>
+        <destination id="local_no_container" runner="local">
+            <env file="{{ galaxy_venv_dir }}/bin/activate"/>
+        </destination>
 {% if galaxy_extras_config_slurm or galaxy_extras_config_pbs or galaxy_extras_config_condor %}
   {% if galaxy_extras_config_pbs %}
         <destination id="pbs_cluster" runner="pbs">


### PR DESCRIPTION
[Updated to describe two commits.]

First commit enables using the ``docker_dispatch`` dynamic rule. GALAXY_DESTINATIONS_DEFAULT is the environment variable that sets the default job destination - this can be set "docker_dispatch" and then two new environment variables will be used - GALAXY_DESTINATIONS_DOCKER_DEFAULT and GALAXY_DESTINATIONS_NO_DOCKER_DEFAULT to determine the destinations for Docker and non-Docker jobs respectively.

The second commit allows fine grain determination of the container resolvers file used by Galaxy. I use this to enable direct annotation and existing BioContainers on quay - but disabling building containers on demand and checking the local Docker host for cached containers (since this isn't available in the Kubernetes setup).
