### PR TITLE
suppress restart of service after munge install as it is not required

### DIFF
--- a/tasks/slurm.yml
+++ b/tasks/slurm.yml
@@ -12,10 +12,6 @@
   apt: pkg=munge state={{ galaxy_extras_apt_package_state }}
   when: galaxy_extras_install_packages
 
-- name: Restart munge service
-  systemd: name=munge daemon_reload=yes enabled=True state=started
-  when: galaxy_extras_install_packages|bool and ansible_distribution_version >= "15.04"
-
 - name: Install SLURM system packages
   apt: pkg={{ item }} state={{ galaxy_extras_apt_package_state }}
   with_items:


### PR DESCRIPTION
@jmchilton This may help planemo machine VM passing the test