### PR TITLE
Allow updating an existing user

### DIFF
--- a/templates/create_galaxy_user.py.j2
+++ b/templates/create_galaxy_user.py.j2
@@ -34,6 +34,9 @@ def add_user(sa_session, security_agent, email, password, key=None, username="ad
             security_agent.user_set_default_permissions( user, history=True, dataset=True )
 
     if key is not None:
+        query = sa_session.query( APIKeys ).filter_by( user_id=user.id ).delete()
+        sa_session.flush()
+        
         api_key = APIKeys()
         api_key.user_id = user.id
         api_key.key = key

--- a/templates/create_galaxy_user.py.j2
+++ b/templates/create_galaxy_user.py.j2
@@ -14,8 +14,13 @@ def add_user(sa_session, security_agent, email, password, key=None, username="ad
         From John https://gist.github.com/jmchilton/4475646
     """
     query = sa_session.query( User ).filter_by( email=email )
+    user = None
     if query.count() > 0:
-        return query.first()
+        user = query.first()
+        user.username = username
+        user.set_password_cleartext(password)
+        sa_session.add(user)
+        sa_session.flush()
     else:
         User.use_pbkdf2 = {{ use_pbkdf2 }}
         user = User(email)
@@ -28,13 +33,13 @@ def add_user(sa_session, security_agent, email, password, key=None, username="ad
         if not user.default_permissions:
             security_agent.user_set_default_permissions( user, history=True, dataset=True )
 
-        if key is not None:
-            api_key = APIKeys()
-            api_key.user_id = user.id
-            api_key.key = key
-            sa_session.add(api_key)
-            sa_session.flush()
-        return user
+    if key is not None:
+        api_key = APIKeys()
+        api_key.user_id = user.id
+        api_key.key = key
+        sa_session.add(api_key)
+        sa_session.flush()
+    return user
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The way this script is currently used in the docker image, it *should* update the existing user with a new password/api key. However, it doesn't.

This patch causes the script to update users even if they're already in the database. Thus, setting GALAXY_DEFAULT_ADMIN_PASSWORD and GALAXY_DEFAULT_ADMIN_KEY to different values at runtime will now work properly instead of silently failing to change the password/api key.

cc @bgruening 