### PR TITLE
Allow many more job runner options at runtime.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -67,6 +67,7 @@ galaxy_extras_gcc_available: false
 
 galaxy_docker_enabled: false
 galaxy_docker_sudo: false
+galaxy_docker_default_image: 'busybox:ubuntu-14.04'
 galaxy_docker_volumes_from: ""
 galaxy_docker_volumes : "$defaults"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -93,6 +93,9 @@ galaxy_reports_log: "{{ galaxy_log_dir }}/reports.log"
 galaxy_db_port: "5432"
 galaxy_database_connection: "postgres://{{ galaxy_user_name }}@localhost:{{ galaxy_db_port }}/galaxy"
 
+# Minimum version to target with configuration.
+galaxy_minimum_version: "17.01"
+
 # Port to serve uwsgi on.
 galaxy_uwsgi: true
 uwsgi_log: "{{ galaxy_log_dir }}/uwsgi.log"

--- a/templates/job_conf.xml.j2
+++ b/templates/job_conf.xml.j2
@@ -57,13 +57,13 @@
             <param id="docker_destination_id" from_environ="GALAXY_DESTINATIONS_DOCKER_DEFAULT">{{ galaxy_extras_galaxy_destination_docker_default }}</param>
             <param id="default_destination_id" from_environ="GALAXY_DESTINATIONS_NO_DOCKER_DEFAULT">{{ galaxy_extras_galaxy_destination_default }}</param>
         </destination>
-        {{ macros.destination("local_no_container", "local") }}
-        {{ macros.destination("local_docker", "local", docker=True) }}
-        {{ macros.destination("local_force_docker", "local", docker=True, force_docker=True) }}
+        {% call macros.destination("local_no_container", "local") %}{% endcall %}
+        {% call macros.destination("local_docker", "local", docker=True) %}{% endcall %}
+        {% call macros.destination("local_force_docker", "local", docker=True, force_docker=True) %}{% endcall %}
 {% if galaxy_extras_config_pbs %}
-        {{ macros.destination("pbs_cluster", "pbs") }}
-        {{ macros.destination("pbs_cluster_docker", "pbs", docker=True) }}
-        {{ macros.destination("pbs_cluster_force_docker", "pbs", docker=True, force_docker=True) }}
+        {% call macros.destination("pbs_cluster", "pbs") %}{% endcall %}
+        {% call macros.destination("pbs_cluster_docker", "pbs", docker=True) %}{% endcall %}
+        {% call macros.destination("pbs_cluster_force_docker", "pbs", docker=True, force_docker=True) %}{% endcall %}
 {% endif %}
 {% if galaxy_extras_config_slurm %}
         {% call macros.destination("slurm_cluster", "slurm") %}
@@ -98,7 +98,7 @@
         {{ macros.docker_dispatch_destination("condor_docker_universe_dispatch", "condor_docker_universe", "condor_cluster")}}
 {% endif %}
 {% if galaxy_extras_config_k8_jobs %}
-        {{ macros.destination("k8_default", "k8", docker=True, force_docker=True) }}
+        {% call macros.destination("k8_default", "k8", docker=True, force_docker=True) %}{% endcall %}
         {{ macros.docker_dispatch_destination("k8_or_local_dispatch", "k8_default", "local_no_container")}}
         {{ macros.docker_dispatch_destination("k8_or_slurm_dispatch", "k8_default", "slurm_cluster")}}
         {{ macros.docker_dispatch_destination("k8_or_condor_dispatch", "k8_default", "condor_cluster")}}

--- a/templates/job_conf.xml.j2
+++ b/templates/job_conf.xml.j2
@@ -60,30 +60,107 @@
         <destination id="local_no_container" runner="local">
             <env file="{{ galaxy_venv_dir }}/bin/activate"/>
         </destination>
+        <destination id="local_docker" runner="local">
+            <env file="{{ galaxy_venv_dir }}/bin/activate"/>
+            {{ macros.docker_enabled() }}
+        </destination>
+        <destination id="local_force_docker" runner="local">
+            <env file="{{ galaxy_venv_dir }}/bin/activate"/>
+            {{ macros.docker_enabled(True) }}
+        </destination>
+        <destination id="local_docker_dispatch" runner="dynamic">
+            <param id="type">docker_dispatch</param>
+            <param id="docker_destination_id">local_docker</param>
+            <param id="default_destination_id">local_no_docker</param>
+        </destination>
 {% if galaxy_extras_config_slurm or galaxy_extras_config_pbs or galaxy_extras_config_condor %}
   {% if galaxy_extras_config_pbs %}
         <destination id="pbs_cluster" runner="pbs">
             <param id="enabled" from_environ="GALAXY_RUNNERS_ENABLE_PBS">true</param>
             <env file="{{ galaxy_venv_dir }}/bin/activate"/>
+        </destination>
+        <destination id="pbs_cluster_docker" runner="pbs">
+            <param id="enabled" from_environ="GALAXY_RUNNERS_ENABLE_PBS">true</param>
+            <env file="{{ galaxy_venv_dir }}/bin/activate"/>
             {{ macros.docker_enabled() }}
         </destination>
+        <destination id="pbs_cluster_force_docker" runner="pbs">
+            <param id="enabled" from_environ="GALAXY_RUNNERS_ENABLE_PBS">true</param>
+            <env file="{{ galaxy_venv_dir }}/bin/activate"/>
+            {{ macros.docker_enabled(True) }}
+        </destination>
+        <!--
+        <destination id="pbs_docker_dispatch" runner="dynamic">
+            <param id="type">docker_dispatch</param>
+            <param id="docker_destination_id">pbs_cluster_docker</param>
+            <param id="default_destination_id">pbs_cluster</param>
+        </destination>
+    -->
  {% endif %}
   {% if galaxy_extras_config_slurm %}
         <destination id="slurm_cluster" runner="slurm">
             <param id="enabled" from_environ="GALAXY_RUNNERS_ENABLE_SLURM">true</param>
             <param id="nativeSpecification" from_environ="NATIVE_SPEC">--ntasks={{ galaxy_extras_slurm_ntask }} --share</param>
             <env file="{{ galaxy_venv_dir }}/bin/activate"/>
+        </destination>
+        <destination id="slurm_cluster_docker" runner="slurm">
+            <param id="enabled" from_environ="GALAXY_RUNNERS_ENABLE_SLURM">true</param>
+            <param id="nativeSpecification" from_environ="NATIVE_SPEC">--ntasks={{ galaxy_extras_slurm_ntask }} --share</param>
+            <env file="{{ galaxy_venv_dir }}/bin/activate"/>
             {{ macros.docker_enabled() }}
         </destination>
+        <destination id="slurm_cluster_force_docker" runner="slurm">
+            <param id="enabled" from_environ="GALAXY_RUNNERS_ENABLE_SLURM">true</param>
+            <param id="nativeSpecification" from_environ="NATIVE_SPEC">--ntasks={{ galaxy_extras_slurm_ntask }} --share</param>
+            <env file="{{ galaxy_venv_dir }}/bin/activate"/>
+            {{ macros.docker_enabled(True) }}
+        </destination>
+        <!--
+        <destination id="slurm_docker_dispatch" runner="dynamic">
+            <param id="type">docker_dispatch</param>
+            <param id="docker_destination_id">slurm_cluster_docker</param>
+            <param id="default_destination_id">slurm_cluster</param>
+        </destination>
+        -->
   {% endif %}
   {% if galaxy_extras_config_condor %}
         <destination id="condor_cluster" runner="condor">
-            <param id="enabled" from_environ="GALAXY_RUNNERS_ENABLE_CONDOR">true</param>
-        {% if galaxy_extras_config_condor_docker %}
-            {{ macros.docker_enabled() }}
-            <param id="universe" from_environ="GALAXY_CONDOR_UNIVERSE">vanilla</param>
-        {% endif %}
             <env file="{{ galaxy_venv_dir }}/bin/activate"/>
+            <param id="enabled" from_environ="GALAXY_RUNNERS_ENABLE_CONDOR">true</param>
+            <param id="universe" from_environ="GALAXY_CONDOR_UNIVERSE">vanilla</param>
+        </destination>
+        <destination id="condor_cluster_docker" runner="condor">
+            <env file="{{ galaxy_venv_dir }}/bin/activate"/>
+            <param id="universe" from_environ="GALAXY_CONDOR_UNIVERSE">vanilla</param>
+            <param id="enabled" from_environ="GALAXY_RUNNERS_ENABLE_CONDOR">true</param>
+            {{ macros.docker_enabled() }}
+        </destination>
+        <destination id="condor_cluster_force_docker" runner="condor">
+            <env file="{{ galaxy_venv_dir }}/bin/activate"/>
+            <param id="universe" from_environ="GALAXY_CONDOR_UNIVERSE">vanilla</param>
+            <param id="enabled" from_environ="GALAXY_RUNNERS_ENABLE_CONDOR">true</param>
+            {{ macros.docker_enabled(True) }}
+        </destination>
+        <destination id="condor_docker_universe" runner="condor">
+            <env file="{{ galaxy_venv_dir }}/bin/activate"/>
+            <param id="universe" from_environ="GALAXY_CONDOR_UNIVERSE">docker</param>
+            <param id="enabled" from_environ="GALAXY_RUNNERS_ENABLE_CONDOR">true</param>
+            {{ macros.docker_enabled(True) }}
+        </destination>
+        <!-- Following destinations send to basic Condor runner if no Docker image is available
+             otherwise they both use the Docker image - the first submits a normal Condor job
+             that will run Docker on the resulting worker node and the second uses Condor's
+             native Docker universe support.
+        -->
+        <destination id="condor_docker_cluster_dispatch" runner="dynamic">
+            <param id="type">docker_dispatch</param>
+            <param id="docker_destination_id">condor_cluster_docker</param>
+            <param id="default_destination_id">condor_cluster</param>
+        </destination>
+        <destination id="condor_docker_universe_dispatch" runner="dynamic">
+            <param id="type">docker_dispatch</param>
+            <param id="docker_destination_id">condor_docker_universe</param>
+            <param id="default_destination_id">condor_cluster</param>
         </destination>
   {% endif %}
   {% if galaxy_extras_config_k8_jobs %}
@@ -92,6 +169,22 @@
             <!-- Following parameter must be set to True for this runner. -->
             <param id="docker_enabled">true</param>
             <env file="{{ galaxy_venv_dir }}/bin/activate"/>
+            <param id="docker_default_container_id" from_environ="GALAXY_DOCKER_DEFAULT_CONTAINER">{{ galaxy_docker_default_image }}</param>
+        </destination>
+        <destination id="k8_or_local_dispatch" runner="dynamic">
+            <param id="type">docker_dispatch</param>
+            <param id="docker_destination_id">k8_default</param>
+            <param id="default_destination_id">local_no_docker</param>
+        </destination>
+        <destination id="k8_or_slurm_dispatch" runner="dynamic">
+            <param id="type">docker_dispatch</param>
+            <param id="docker_destination_id">k8_default</param>
+            <param id="default_destination_id">slurm_cluster</param>
+        </destination>
+        <destination id="k8_or_condor_dispatch" runner="dynamic">
+            <param id="type">docker_dispatch</param>
+            <param id="docker_destination_id">k8_default</param>
+            <param id="default_destination_id">condor_cluster</param>
         </destination>
   {% endif %}
 

--- a/templates/job_conf.xml.j2
+++ b/templates/job_conf.xml.j2
@@ -57,137 +57,51 @@
             <param id="docker_destination_id" from_environ="GALAXY_DESTINATIONS_DOCKER_DEFAULT">{{ galaxy_extras_galaxy_destination_docker_default }}</param>
             <param id="default_destination_id" from_environ="GALAXY_DESTINATIONS_NO_DOCKER_DEFAULT">{{ galaxy_extras_galaxy_destination_default }}</param>
         </destination>
-        <destination id="local_no_container" runner="local">
-            <env file="{{ galaxy_venv_dir }}/bin/activate"/>
-        </destination>
-        <destination id="local_docker" runner="local">
-            <env file="{{ galaxy_venv_dir }}/bin/activate"/>
-            {{ macros.docker_enabled() }}
-        </destination>
-        <destination id="local_force_docker" runner="local">
-            <env file="{{ galaxy_venv_dir }}/bin/activate"/>
-            {{ macros.docker_enabled(True) }}
-        </destination>
-        <destination id="local_docker_dispatch" runner="dynamic">
-            <param id="type">docker_dispatch</param>
-            <param id="docker_destination_id">local_docker</param>
-            <param id="default_destination_id">local_no_docker</param>
-        </destination>
-{% if galaxy_extras_config_slurm or galaxy_extras_config_pbs or galaxy_extras_config_condor %}
-  {% if galaxy_extras_config_pbs %}
-        <destination id="pbs_cluster" runner="pbs">
-            <param id="enabled" from_environ="GALAXY_RUNNERS_ENABLE_PBS">true</param>
-            <env file="{{ galaxy_venv_dir }}/bin/activate"/>
-        </destination>
-        <destination id="pbs_cluster_docker" runner="pbs">
-            <param id="enabled" from_environ="GALAXY_RUNNERS_ENABLE_PBS">true</param>
-            <env file="{{ galaxy_venv_dir }}/bin/activate"/>
-            {{ macros.docker_enabled() }}
-        </destination>
-        <destination id="pbs_cluster_force_docker" runner="pbs">
-            <param id="enabled" from_environ="GALAXY_RUNNERS_ENABLE_PBS">true</param>
-            <env file="{{ galaxy_venv_dir }}/bin/activate"/>
-            {{ macros.docker_enabled(True) }}
-        </destination>
-        <!--
-        <destination id="pbs_docker_dispatch" runner="dynamic">
-            <param id="type">docker_dispatch</param>
-            <param id="docker_destination_id">pbs_cluster_docker</param>
-            <param id="default_destination_id">pbs_cluster</param>
-        </destination>
-    -->
- {% endif %}
-  {% if galaxy_extras_config_slurm %}
-        <destination id="slurm_cluster" runner="slurm">
-            <param id="enabled" from_environ="GALAXY_RUNNERS_ENABLE_SLURM">true</param>
+        {{ macros.destination("local_no_container", "local") }}
+        {{ macros.destination("local_docker", "local", docker=True) }}
+        {{ macros.destination("local_force_docker", "local", docker=True, force_docker=True) }}
+{% if galaxy_extras_config_pbs %}
+        {{ macros.destination("pbs_cluster", "pbs") }}
+        {{ macros.destination("pbs_cluster_docker", "pbs", docker=True) }}
+        {{ macros.destination("pbs_cluster_force_docker", "pbs", docker=True, force_docker=True) }}
+{% endif %}
+{% if galaxy_extras_config_slurm %}
+        {% call macros.destination("slurm_cluster", "slurm") %}
             <param id="nativeSpecification" from_environ="NATIVE_SPEC">--ntasks={{ galaxy_extras_slurm_ntask }} --share</param>
-            <env file="{{ galaxy_venv_dir }}/bin/activate"/>
-        </destination>
-        <destination id="slurm_cluster_docker" runner="slurm">
-            <param id="enabled" from_environ="GALAXY_RUNNERS_ENABLE_SLURM">true</param>
+        {% endcall %}
+        {% call macros.destination("slurm_cluster_docker", "slurm", docker=True) %}
             <param id="nativeSpecification" from_environ="NATIVE_SPEC">--ntasks={{ galaxy_extras_slurm_ntask }} --share</param>
-            <env file="{{ galaxy_venv_dir }}/bin/activate"/>
-            {{ macros.docker_enabled() }}
-        </destination>
-        <destination id="slurm_cluster_force_docker" runner="slurm">
-            <param id="enabled" from_environ="GALAXY_RUNNERS_ENABLE_SLURM">true</param>
+        {% endcall %}
+        {% call macros.destination("slurm_cluster_force_docker", "slurm", docker=True, force_docker=True) %}
             <param id="nativeSpecification" from_environ="NATIVE_SPEC">--ntasks={{ galaxy_extras_slurm_ntask }} --share</param>
-            <env file="{{ galaxy_venv_dir }}/bin/activate"/>
-            {{ macros.docker_enabled(True) }}
-        </destination>
-        <!--
-        <destination id="slurm_docker_dispatch" runner="dynamic">
-            <param id="type">docker_dispatch</param>
-            <param id="docker_destination_id">slurm_cluster_docker</param>
-            <param id="default_destination_id">slurm_cluster</param>
-        </destination>
-        -->
-  {% endif %}
-  {% if galaxy_extras_config_condor %}
-        <destination id="condor_cluster" runner="condor">
-            <env file="{{ galaxy_venv_dir }}/bin/activate"/>
-            <param id="enabled" from_environ="GALAXY_RUNNERS_ENABLE_CONDOR">true</param>
+        {% endcall %}
+{% endif %}
+{% if galaxy_extras_config_condor %}
+        {% call macros.destination("condor_cluster", "condor") %}
             <param id="universe" from_environ="GALAXY_CONDOR_UNIVERSE">vanilla</param>
-        </destination>
-        <destination id="condor_cluster_docker" runner="condor">
-            <env file="{{ galaxy_venv_dir }}/bin/activate"/>
+        {% endcall %}
+        {% call macros.destination("condor_cluster_docker", "condor", docker=True) %}
             <param id="universe" from_environ="GALAXY_CONDOR_UNIVERSE">vanilla</param>
-            <param id="enabled" from_environ="GALAXY_RUNNERS_ENABLE_CONDOR">true</param>
-            {{ macros.docker_enabled() }}
-        </destination>
-        <destination id="condor_cluster_force_docker" runner="condor">
-            <env file="{{ galaxy_venv_dir }}/bin/activate"/>
+        {% endcall %}
+        {% call macros.destination("condor_cluster_force_docker", "condor", docker=True, force_docker=True) %}
             <param id="universe" from_environ="GALAXY_CONDOR_UNIVERSE">vanilla</param>
-            <param id="enabled" from_environ="GALAXY_RUNNERS_ENABLE_CONDOR">true</param>
-            {{ macros.docker_enabled(True) }}
-        </destination>
-        <destination id="condor_docker_universe" runner="condor">
-            <env file="{{ galaxy_venv_dir }}/bin/activate"/>
+        {% endcall %}
+        {% call macros.destination("condor_docker_universe", "condor", docker=True, force_docker=True) %}
             <param id="universe" from_environ="GALAXY_CONDOR_UNIVERSE">docker</param>
-            <param id="enabled" from_environ="GALAXY_RUNNERS_ENABLE_CONDOR">true</param>
-            {{ macros.docker_enabled(True) }}
-        </destination>
+        {% endcall %}
         <!-- Following destinations send to basic Condor runner if no Docker image is available
              otherwise they both use the Docker image - the first submits a normal Condor job
              that will run Docker on the resulting worker node and the second uses Condor's
              native Docker universe support.
         -->
-        <destination id="condor_docker_cluster_dispatch" runner="dynamic">
-            <param id="type">docker_dispatch</param>
-            <param id="docker_destination_id">condor_cluster_docker</param>
-            <param id="default_destination_id">condor_cluster</param>
-        </destination>
-        <destination id="condor_docker_universe_dispatch" runner="dynamic">
-            <param id="type">docker_dispatch</param>
-            <param id="docker_destination_id">condor_docker_universe</param>
-            <param id="default_destination_id">condor_cluster</param>
-        </destination>
-  {% endif %}
-  {% if galaxy_extras_config_k8_jobs %}
-        <destination id="k8_default" runner="k8">
-            <param id="enabled" from_environ="GALAXY_RUNNERS_ENABLE_K8">true</param>
-            <!-- Following parameter must be set to True for this runner. -->
-            <param id="docker_enabled">true</param>
-            <env file="{{ galaxy_venv_dir }}/bin/activate"/>
-            <param id="docker_default_container_id" from_environ="GALAXY_DOCKER_DEFAULT_CONTAINER">{{ galaxy_docker_default_image }}</param>
-        </destination>
-        <destination id="k8_or_local_dispatch" runner="dynamic">
-            <param id="type">docker_dispatch</param>
-            <param id="docker_destination_id">k8_default</param>
-            <param id="default_destination_id">local_no_docker</param>
-        </destination>
-        <destination id="k8_or_slurm_dispatch" runner="dynamic">
-            <param id="type">docker_dispatch</param>
-            <param id="docker_destination_id">k8_default</param>
-            <param id="default_destination_id">slurm_cluster</param>
-        </destination>
-        <destination id="k8_or_condor_dispatch" runner="dynamic">
-            <param id="type">docker_dispatch</param>
-            <param id="docker_destination_id">k8_default</param>
-            <param id="default_destination_id">condor_cluster</param>
-        </destination>
-  {% endif %}
-
+        {{ macros.docker_dispatch_destination("condor_docker_cluster_dispatch", "condor_cluster_docker", "condor_cluster")}}
+        {{ macros.docker_dispatch_destination("condor_docker_universe_dispatch", "condor_docker_universe", "condor_cluster")}}
+{% endif %}
+{% if galaxy_extras_config_k8_jobs %}
+        {{ macros.destination("k8_default", "k8", docker=True, force_docker=True) }}
+        {{ macros.docker_dispatch_destination("k8_or_local_dispatch", "k8_default", "local_no_container")}}
+        {{ macros.docker_dispatch_destination("k8_or_slurm_dispatch", "k8_default", "slurm_cluster")}}
+        {{ macros.docker_dispatch_destination("k8_or_condor_dispatch", "k8_default", "condor_cluster")}}
 {% endif %}
     </destinations>
     <limits>

--- a/templates/job_conf.xml.j2
+++ b/templates/job_conf.xml.j2
@@ -5,14 +5,24 @@
 {% if galaxy_extras_config_slurm %}
         <plugin id="slurm" type="runner" load="galaxy.jobs.runners.slurm:SlurmJobRunner">
             <param id="drmaa_library_path">/usr/lib/slurm-drmaa/lib/libdrmaa.so</param>
+{% if galaxy_minimum_version >= "17.09" %}
+            <param id="enabled" from_environ="GALAXY_RUNNERS_ENABLE_SLURM">true</param>
+{% endif %}
         </plugin>
 {% endif %}
 {% if galaxy_extras_config_condor %}
-        <plugin id="condor" type="runner" load="galaxy.jobs.runners.condor:CondorJobRunner" />
+        <plugin id="condor" type="runner" load="galaxy.jobs.runners.condor:CondorJobRunner">
+{% if galaxy_minimum_version >= "17.09" %}
+            <param id="enabled" from_environ="GALAXY_RUNNERS_ENABLE_CONDOR">true</param>
+{% endif %}
+        </plugin>
 {% endif %}
 {% if galaxy_extras_config_pbs %}
         <plugin id="pbs" type="runner" load="galaxy.jobs.runners.drmaa:DRMAAJobRunner">
             <param id="drmaa_library_path">/usr/lib/pbs-drmaa/lib/libdrmaa.so.1</param>
+{% if galaxy_minimum_version >= "17.09" %}
+            <param id="enabled" from_environ="GALAXY_RUNNERS_ENABLE_PBS">true</param>
+{% endif %}
         </plugin>
 {% endif %}
 {% if galaxy_extras_config_k8_jobs %}
@@ -21,6 +31,9 @@
             <param id="k8s_use_service_account">true</param>
             <param id="k8s_persistent_volume_claim_name">galaxy-web-claim0</param>
             <param id="k8s_persistent_volume_claim_mount_path">/export</param>
+{% if galaxy_minimum_version >= "17.09" %}
+            <param id="enabled" from_environ="GALAXY_RUNNERS_ENABLE_K8">true</param>
+{% endif %}
         </plugin>
 {% endif %}
         <plugin id="local" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner"/>
@@ -50,12 +63,14 @@
 {% if galaxy_extras_config_slurm or galaxy_extras_config_pbs or galaxy_extras_config_condor %}
   {% if galaxy_extras_config_pbs %}
         <destination id="pbs_cluster" runner="pbs">
+            <param id="enabled" from_environ="GALAXY_RUNNERS_ENABLE_PBS">true</param>
             <env file="{{ galaxy_venv_dir }}/bin/activate"/>
             {{ macros.docker_enabled() }}
         </destination>
  {% endif %}
   {% if galaxy_extras_config_slurm %}
         <destination id="slurm_cluster" runner="slurm">
+            <param id="enabled" from_environ="GALAXY_RUNNERS_ENABLE_SLURM">true</param>
             <param id="nativeSpecification" from_environ="NATIVE_SPEC">--ntasks={{ galaxy_extras_slurm_ntask }} --share</param>
             <env file="{{ galaxy_venv_dir }}/bin/activate"/>
             {{ macros.docker_enabled() }}
@@ -63,6 +78,7 @@
   {% endif %}
   {% if galaxy_extras_config_condor %}
         <destination id="condor_cluster" runner="condor">
+            <param id="enabled" from_environ="GALAXY_RUNNERS_ENABLE_CONDOR">true</param>
         {% if galaxy_extras_config_condor_docker %}
             {{ macros.docker_enabled() }}
             <param id="universe" from_environ="GALAXY_CONDOR_UNIVERSE">vanilla</param>
@@ -72,6 +88,7 @@
   {% endif %}
   {% if galaxy_extras_config_k8_jobs %}
         <destination id="k8_default" runner="k8">
+            <param id="enabled" from_environ="GALAXY_RUNNERS_ENABLE_K8">true</param>
             <!-- Following parameter must be set to True for this runner. -->
             <param id="docker_enabled">true</param>
             <env file="{{ galaxy_venv_dir }}/bin/activate"/>

--- a/templates/macros.xml.j2
+++ b/templates/macros.xml.j2
@@ -1,7 +1,10 @@
-{% macro docker_enabled(force_docker=False) -%}
+{% macro destination(id, runner, docker=False, force_docker=False) -%}
+    <destination id="{{ id }}" runner="{{ runner }}">
+        <env file="{{ galaxy_venv_dir }}/bin/activate"/>
     {% if galaxy_source_shellrc %}
         <env file="{{ galaxy_user_shellrc }}" />
     {% endif %}
+        <param id="enabled" from_environ="GALAXY_RUNNERS_ENABLE_{{ runner|upper }}">true</param>
         <param id="docker_enabled">true</param>
         <param id="docker_sudo" from_environ="GALAXY_DOCKER_SUDO">{{ galaxy_docker_sudo }}</param>
         <!-- The empty volumes from shouldn't affect Galaxy, set GALAXY_DOCKER_VOLUMES_FROM to use. -->
@@ -11,4 +14,14 @@
     {% if force_docker %}
         <param id="docker_default_container_id" from_environ="GALAXY_DOCKER_DEFAULT_CONTAINER">{{ galaxy_docker_default_image }}</param>
     {% endif %}
+        {{ caller() }}
+    </destination>
+{%- endmacro %}
+
+{% macro docker_dispatch_destination(id, default_destination, docker_destination) -%}
+    <destination id="{{ id }}" runner="dynamic">
+        <param id="type">docker_dispatch</param>
+        <param id="docker_destination_id">{{ docker_destination }}</param>
+        <param id="default_destination_id">{{ default_destination }}</param>
+    </destination>
 {%- endmacro %}

--- a/templates/macros.xml.j2
+++ b/templates/macros.xml.j2
@@ -1,11 +1,14 @@
-{% macro docker_enabled() -%}
+{% macro docker_enabled(force_docker=False) -%}
     {% if galaxy_source_shellrc %}
         <env file="{{ galaxy_user_shellrc }}" />
     {% endif %}
-        <param id="docker_enabled" from_environ="GALAXY_DOCKER_ENABLED">{{ galaxy_docker_enabled }}</param>
+        <param id="docker_enabled">true</param>
         <param id="docker_sudo" from_environ="GALAXY_DOCKER_SUDO">{{ galaxy_docker_sudo }}</param>
         <!-- The empty volumes from shouldn't affect Galaxy, set GALAXY_DOCKER_VOLUMES_FROM to use. -->
         <param id="docker_volumes_from" from_environ="GALAXY_DOCKER_VOLUMES_FROM">{{ galaxy_docker_volumes_from }}</param>
         <!-- For a stock Galaxy instance and traditional job runner $defaults will expand out as: $galaxy_root:ro,$tool_directory:ro,$working_directory:rw,$default_file_path:rw -->
         <param id="docker_volumes" from_environ="GALAXY_DOCKER_VOLUMES">{{ galaxy_docker_volumes }}</param>
+    {% if force_docker %}
+        <param id="docker_default_container_id" from_environ="GALAXY_DOCKER_DEFAULT_CONTAINER">{{ galaxy_docker_default_image }}</param>
+    {% endif %}
 {%- endmacro %}


### PR DESCRIPTION
Flush out the job configuration file with many more job destinations, allowing different runtime defaults for the built containers using just the configuration variable GALAXY_DESTINATIONS_DEFAULT.

The options are:

- `local_no_container`: Use the local runner, do not use Docker.
- `local_docker`: Use the local runner along with Docker if a container for the tool can be found.
- `local_force_docker`: Use the local runner and force tools to use Docker*.
- `pbs_cluster`: Use PBS cluster without Docker.
- `pbs_cluster_docker`: Use PBS cluster with Docker if a container for the tool can be found.
- `pbs_cluster_force_docker`: Use PBS cluster and force tools to use Docker*.
- `slurm_cluster`: Use SLURM, do not use Docker.
- `slurm_cluster_docker`: Use SLURM and use Docker if a container for the tool can be found.
- `slurm_cluster_force_docker`: Use SLURM and force tools to use Docker*
- `condor_cluster`: Use Condor, do not use Docker.
- `condor_cluster_docker`: Use Condor, use Docker as part of job script if a container can be found.
- `condor_cluster_force_docker`: Use Condor, force Docker usage*.
- `condor_docker_universe`: Use Condor through Docker universe*.
- `condor_docker_universe_dispatch`: Use Condor through Docker universe if a container for the tool can be found, else use the vanilla universe.
- `k8_default`: Run through Docker on Kubernetes*.
- `k8_or_local_dispatch`: If a container for the tool can be found, run on Kubernetes else on local runner (`local_no_container`).
- `k8_or_slurm_dispatch`: If a container for the tool can be found, run on Kubernetes else on SLURM (`slurm_cluster`).
- `k8_or_condor_dispatch`: If a container for the tool can be found, run on Kubernetes else on Condor as a cluster job (`condor_cluster`).
- `docker_dispatch`: Dispatch between any two using the enironment variables `GALAXY_DESTINATIONS_DOCKER_DEFAULT` and `GALAXY_DESTINATIONS_NO_DOCKER_DEFAULT`.

\* `GALAXY_DOCKER_DEFAULT_CONTAINER` will be used for the default container if no tool-specific container is located.

Subtlety breaks backward compatibility for certain edge case configurations - probably only affecting docker-galaxy-stable?.


