### PR TITLE
Synchronize nginx error doc handling with ansible-galaxy role.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -140,6 +140,9 @@ nginx_ide_location: "{{ nginx_prefix_location }}/ide"
 nginx_welcome_location: "{{ nginx_prefix_location }}/etc/galaxy/web"
 nginx_welcome_path: "/etc/galaxy/web"
 
+# Synchronize error handling with ansible-galaxy role.
+galaxy_errordocs_dest: "/root/"
+
 #web security
 nginx_use_passwords: False
 nginx_htpasswds:

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -192,10 +192,12 @@ http {
         }
 {% endif %}
 
-        error_page 502  {{ nginx_prefix_location }}/502.html;
-        location = {{ nginx_prefix_location }}/502.html {
-            root  /root/;
-            proxy_intercept_errors on;
+        # error docs
+        error_page  502 503 504 {{ nginx_prefix_location }}/error/502/index.shtml;
+        error_page  413         {{ nginx_prefix_location }}/error/413/index.html;
+        location {{ nginx_prefix_location }}/error {
+            ssi on;
+            alias {{ galaxy_errordocs_dest }};
         }
 
 


### PR DESCRIPTION
Probably shouldn't break anything for existing setup since I don't think docker-galaxy-stable for instance was writing anything to /root/502.html right?

xref https://github.com/galaxyproject/ansible-galaxy/commit/1bff199822c7c8456a6d2ff802ec98732c57a4d0
xref https://github.com/galaxyproject/planemo-machine/issues/85