### PR TITLE
Increase buffer size for uWSGI

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -9,6 +9,10 @@ events {
 http {
     include       mime.types;
     default_type  application/octet-stream;
+    
+    uwsgi_buffers 8 16384;
+    uwsgi_buffer_size 16384;
+
 
     sendfile        on;
 

--- a/templates/supervisor.conf.j2
+++ b/templates/supervisor.conf.j2
@@ -102,9 +102,9 @@ priority        = 200
 [program:galaxy_web]
 {% if galaxy_uwsgi|bool %}
 {% if galaxy_uwsgi_static_conf|bool %}
-command         = {{ galaxy_venv_dir }}/bin/uwsgi --virtualenv {{ galaxy_venv_dir }} --ini-paste {{ galaxy_config_file }} --logdate --master --processes {{ galaxy_web_processes }} --threads {{ uwsgi_threads }} --logto {{ uwsgi_log }} --socket 127.0.0.1:4001 --pythonpath lib --stats 127.0.0.1:9191 -b 32768
+command         = {{ galaxy_venv_dir }}/bin/uwsgi --virtualenv {{ galaxy_venv_dir }} --ini-paste {{ galaxy_config_file }} --logdate --master --processes {{ galaxy_web_processes }} --threads {{ uwsgi_threads }} --logto {{ uwsgi_log }} --socket 127.0.0.1:4001 --pythonpath lib --stats 127.0.0.1:9191 -b 16384
 {% else %}
-command         = {{ galaxy_venv_dir }}/bin/uwsgi --virtualenv {{ galaxy_venv_dir }} --ini-paste {{ galaxy_config_file }} --logdate --master --processes %(ENV_UWSGI_PROCESSES)s --threads %(ENV_UWSGI_THREADS)s --logto {{ uwsgi_log }} --socket 127.0.0.1:4001 --pythonpath lib --stats 127.0.0.1:9191 -b 32768
+command         = {{ galaxy_venv_dir }}/bin/uwsgi --virtualenv {{ galaxy_venv_dir }} --ini-paste {{ galaxy_config_file }} --logdate --master --processes %(ENV_UWSGI_PROCESSES)s --threads %(ENV_UWSGI_THREADS)s --logto {{ uwsgi_log }} --socket 127.0.0.1:4001 --pythonpath lib --stats 127.0.0.1:9191 -b 16384
 {% endif %}
 directory       = {{ galaxy_server_dir }}
 umask           = 022

--- a/templates/supervisor.conf.j2
+++ b/templates/supervisor.conf.j2
@@ -102,9 +102,9 @@ priority        = 200
 [program:galaxy_web]
 {% if galaxy_uwsgi|bool %}
 {% if galaxy_uwsgi_static_conf|bool %}
-command         = {{ galaxy_venv_dir }}/bin/uwsgi --virtualenv {{ galaxy_venv_dir }} --ini-paste {{ galaxy_config_file }} --logdate --master --processes {{ galaxy_web_processes }} --threads {{ uwsgi_threads }} --logto {{ uwsgi_log }} --socket 127.0.0.1:4001 --pythonpath lib --stats 127.0.0.1:9191
+command         = {{ galaxy_venv_dir }}/bin/uwsgi --virtualenv {{ galaxy_venv_dir }} --ini-paste {{ galaxy_config_file }} --logdate --master --processes {{ galaxy_web_processes }} --threads {{ uwsgi_threads }} --logto {{ uwsgi_log }} --socket 127.0.0.1:4001 --pythonpath lib --stats 127.0.0.1:9191 -b 32768
 {% else %}
-command         = {{ galaxy_venv_dir }}/bin/uwsgi --virtualenv {{ galaxy_venv_dir }} --ini-paste {{ galaxy_config_file }} --logdate --master --processes %(ENV_UWSGI_PROCESSES)s --threads %(ENV_UWSGI_THREADS)s --logto {{ uwsgi_log }} --socket 127.0.0.1:4001 --pythonpath lib --stats 127.0.0.1:9191
+command         = {{ galaxy_venv_dir }}/bin/uwsgi --virtualenv {{ galaxy_venv_dir }} --ini-paste {{ galaxy_config_file }} --logdate --master --processes %(ENV_UWSGI_PROCESSES)s --threads %(ENV_UWSGI_THREADS)s --logto {{ uwsgi_log }} --socket 127.0.0.1:4001 --pythonpath lib --stats 127.0.0.1:9191 -b 32768
 {% endif %}
 directory       = {{ galaxy_server_dir }}
 umask           = 022


### PR DESCRIPTION
Default buffer size in uWSGI is 4096.
But it's small for long error message.

In my case , I try to import workflow  to clean docker galaxy instance ,
the galaxy instance has no tool for the workflow.
Error message is long , like this

```
/admin?status=error&message=Imported%2C+but+some+steps+in+this+workflow+have+validation+err
```
uwsgi.log error message has like this

```
invalid request block size: 4098 (max 4096).
```

but increase buffer size , there is no uwsgi error