### PR TITLE
Hide "no such file or directory" warning

### DIFF
--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -92,7 +92,7 @@ if [ "x$DISABLE_REPORTS_AUTH" != "x" ]
     then
         # disable authentification
         echo "Disable Galaxy reports authentification "
-        rm /etc/nginx/htpasswd
+        rm -f /etc/nginx/htpasswd
         echo "" > /etc/nginx/conf.d/reports_auth.conf
     else
         # enable authentification


### PR DESCRIPTION
Just a tiny patch to avoid a warning in the logs