### PR TITLE
Preloading IE docker images in startup.sh

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,8 +52,6 @@ galaxy_extras_install_packages: false
 # be 'present' or 'latest'.
 galaxy_extras_apt_package_state: present
 
-galaxy_extras_ie_fetch_ipython: false
-galaxy_extras_ie_ipython_image: bgruening/docker-ipython-notebook:dev #deprecated
 galaxy_extras_ie_fetch_jupyter: false
 galaxy_extras_ie_jupyter_image: quay.io/bgruening/docker-jupyter-notebook:17.05
 galaxy_extras_ie_fetch_rstudio: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,11 +53,11 @@ galaxy_extras_install_packages: false
 galaxy_extras_apt_package_state: present
 
 galaxy_extras_ie_fetch_ipython: false
-galaxy_extras_ie_ipython_image: bgruening/docker-ipython-notebook:dev
+galaxy_extras_ie_ipython_image: bgruening/docker-ipython-notebook:dev #deprecated
 galaxy_extras_ie_fetch_jupyter: false
-galaxy_extras_ie_jupyter_image: bgruening/docker-jupyter-notebook:16.01
+galaxy_extras_ie_jupyter_image: quay.io/bgruening/docker-jupyter-notebook:17.05
 galaxy_extras_ie_fetch_rstudio: false
-galaxy_extras_ie_rstudio_image: erasche/docker-rstudio-notebook:15.10
+galaxy_extras_ie_rstudio_image: erasche/docker-rstudio-notebook:17.01
 
 # The storage backend to use for docker-in-docker.
 # aufs on parent docker cannot be combined with aufs in child docker

--- a/tasks/ie_proxy.yml
+++ b/tasks/ie_proxy.yml
@@ -10,11 +10,6 @@
   become: True
   become_user: "{{ galaxy_user_name }}"
 
-- name: "Install IPython container."
-  shell: "docker pull {{ galaxy_extras_ie_ipython_image }}"
-  become: True
-  when: galaxy_extras_ie_fetch_ipython
-
 - name: "Install Juypter container."
   shell: "docker pull {{ galaxy_extras_ie_juypter_image }}"
   become: True

--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -349,6 +349,12 @@ if $PRIVILEGED; then
         echo "{{ galaxy_user_name }} ALL = NOPASSWD : ALL" >> /etc/sudoers
         start_supervisor
     fi
+    if  [ "x$PULL_IE_IMAGES" != "x" ]; then
+        echo "Pull images for interactive environments"
+        docker pull {{ galaxy_extras_ie_ipython_image }} &
+        docker pull {{ galaxy_extras_ie_jupyter_image }} &
+        docker pull {{ galaxy_extras_ie_rstudio_image }} &
+    fi
 else
     echo "Disable Galaxy Interactive Environments. Start with --privileged to enable IE's."
     export GALAXY_CONFIG_INTERACTIVE_ENVIRONMENT_PLUGINS_DIRECTORY=""

--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -351,8 +351,8 @@ if $PRIVILEGED; then
     fi
     if  [ "x$PULL_IE_IMAGES" != "x" ]; then
         echo "Pull images for interactive environments. Caveat : Depending on the side of the images, this migth be an intensive task in terms of disc space, running time, network brandwith and CPU usage.    "
-        docker pull {{ galaxy_extras_ie_jupyter_image }} &
-        docker pull {{ galaxy_extras_ie_rstudio_image }} &
+        docker pull {{ galaxy_extras_ie_jupyter_image }}
+        docker pull {{ galaxy_extras_ie_rstudio_image }}
     fi
 else
     echo "Disable Galaxy Interactive Environments. Start with --privileged to enable IE's."

--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -351,7 +351,6 @@ if $PRIVILEGED; then
     fi
     if  [ "x$PULL_IE_IMAGES" != "x" ]; then
         echo "Pull images for interactive environments"
-        docker pull {{ galaxy_extras_ie_ipython_image }} &
         docker pull {{ galaxy_extras_ie_jupyter_image }} &
         docker pull {{ galaxy_extras_ie_rstudio_image }} &
     fi


### PR DESCRIPTION
- Added PULL_IE_IMAGES environmental variable to the startup script.
- Startup.sh is now able to load the required images in the background while Galaxy starts.
- Default IE images are updated to be the same as the Galaxy default images
- Removed references to deprecated ipython image.

This change was requested in https://github.com/bgruening/docker-galaxy-stable/issues/306
Hacked together at GCC2017 by @jvanbraekel, @thobalose and @rhpvorderman.
