### PR TITLE
Enable loading of conditional requirements in /usr/bin/startup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,4 +51,6 @@ script:
   - make test_bioblend
   #- make test_docker_in_docker
   # Test the conditional loading of dependencies.
-  - bash ./tests/conditional_deps/test_script.sh
+  - echo $PWD
+  - ls
+  - bash tests/conditional_deps/test_script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,16 +51,4 @@ script:
   - make test_bioblend
   #- make test_docker_in_docker
   # Test the conditional loading of dependencies.
-  - >
-    docker run -d -p 8080:80 -p 8021:21 -p 8022:22
-    --name galaxy_test_container
-    -e GALAXY_CONFIG_AUTH_CONFIG_FILE=config/auth_conf.xml
-    -v tests/conditional_deps/auth_conf.xml:/galaxy-central/config/auth_conf.xml
-    --name galaxy-test
-    galaxy-docker/test
-  - docker ps
-  - sleep 30
-  - >
-    docker exec -u 1450 galaxy-test /galaxy_venv/bin/pip list --format=columns | grep python -ldap
-    if [$? == 0 ]; then echo "Conditional dependency loaded";
-    else echo "Conditional dependency not loaded!" && exit 1 ; fi
+  - test/conditional_deps/test_scripts.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,4 +51,4 @@ script:
   - make test_bioblend
   #- make test_docker_in_docker
   # Test the conditional loading of dependencies.
-  - bash ./tests/conditional_deps/test_scripts.sh
+  - bash ./tests/conditional_deps/test_script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,4 +51,4 @@ script:
   - make test_bioblend
   #- make test_docker_in_docker
   # Test the conditional loading of dependencies.
-  - bash ./test/conditional_deps/test_scripts.sh
+  - bash ./tests/conditional_deps/test_scripts.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,3 +50,15 @@ script:
   - make test_ftp
   - make test_bioblend
   #- make test_docker_in_docker
+  # Test the conditional loading of dependencies.
+  - docker run -d -p 8080:80 -p 8021:21 -p 8022:22 \
+  - --name galaxy_test_container \
+  - -e GALAXY_CONFIG_AUTH_CONFIG_FILE=config/auth_conf.xml \
+  - -v tests/conditional_deps/auth_conf.xml:/galaxy-central/config/auth_conf.xml \
+  - --name galaxy-test \
+  - galaxy-docker/test
+  - docker ps
+  - docker exec -u 1450 galaxy-test /galaxy_venv/bin/pip list --format=columns | grep python -ldap \
+  - if [$? == 0 ]; then echo "Conditional dependency loaded"; \
+  - else echo "Conditional dependency not loaded!" && exit 1 ; fi
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,15 +51,17 @@ script:
   - make test_bioblend
   #- make test_docker_in_docker
   # Test the conditional loading of dependencies.
-  - docker run -d -p 8080:80 -p 8021:21 -p 8022:22 \
-  - --name galaxy_test_container \
-  - -e GALAXY_CONFIG_AUTH_CONFIG_FILE=config/auth_conf.xml \
-  - -e FETCH_WHEELS=True \
-  - -v tests/conditional_deps/auth_conf.xml:/galaxy-central/config/auth_conf.xml \
-  - --name galaxy-test \
-  - galaxy-docker/test
+  - >
+    docker run -d -p 8080:80 -p 8021:21 -p 8022:22
+    --name galaxy_test_container
+    -e GALAXY_CONFIG_AUTH_CONFIG_FILE=config/auth_conf.xml
+    -e FETCH_WHEELS=True
+    -v tests/conditional_deps/auth_conf.xml:/galaxy-central/config/auth_conf.xml
+    --name galaxy-test
+    galaxy-docker/test
   - docker ps
   - sleep 30
-  - docker exec -u 1450 galaxy-test /galaxy_venv/bin/pip list --format=columns | grep python -ldap \
-  - if [$? == 0 ]; then echo "Conditional dependency loaded"; \
-  - else echo "Conditional dependency not loaded!" && exit 1 ; fi
+  - >
+    docker exec -u 1450 galaxy-test /galaxy_venv/bin/pip list --format=columns | grep python -ldap
+    if [$? == 0 ]; then echo "Conditional dependency loaded";
+    else echo "Conditional dependency not loaded!" && exit 1 ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,5 @@ script:
   - make test_bioblend
   #- make test_docker_in_docker
   # Test the conditional loading of dependencies.
-  - echo $PWD
-  - ls
+  - cd $HOME/galaxy-docker/galaxy/roles/galaxyprojectdotorg.galaxyextras/
   - bash tests/conditional_deps/test_script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,11 +54,12 @@ script:
   - docker run -d -p 8080:80 -p 8021:21 -p 8022:22 \
   - --name galaxy_test_container \
   - -e GALAXY_CONFIG_AUTH_CONFIG_FILE=config/auth_conf.xml \
+  - -e FETCH_WHEELS=True \
   - -v tests/conditional_deps/auth_conf.xml:/galaxy-central/config/auth_conf.xml \
   - --name galaxy-test \
   - galaxy-docker/test
   - docker ps
+  - sleep 30
   - docker exec -u 1450 galaxy-test /galaxy_venv/bin/pip list --format=columns | grep python -ldap \
   - if [$? == 0 ]; then echo "Conditional dependency loaded"; \
   - else echo "Conditional dependency not loaded!" && exit 1 ; fi
-  

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,4 +51,4 @@ script:
   - make test_bioblend
   #- make test_docker_in_docker
   # Test the conditional loading of dependencies.
-  - test/conditional_deps/test_scripts.sh
+  - bash ./test/conditional_deps/test_scripts.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,6 @@ script:
     docker run -d -p 8080:80 -p 8021:21 -p 8022:22
     --name galaxy_test_container
     -e GALAXY_CONFIG_AUTH_CONFIG_FILE=config/auth_conf.xml
-    -e FETCH_WHEELS=True
     -v tests/conditional_deps/auth_conf.xml:/galaxy-central/config/auth_conf.xml
     --name galaxy-test
     galaxy-docker/test

--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -117,17 +117,17 @@ if [[ $NONUSE != *"load_python_optional_dependencies"* ]]
     then
         echo "Installing optional dependencies in galaxy virtual environment..."
         : ${GALAXY_WHEELS_INDEX_URL:="https://wheels.galaxyproject.org/simple"}
-        pip install -r requirements.txt --index-url "${GALAXY_WHEELS_INDEX_URL}"
+        pip install -q -r requirements.txt --index-url "${GALAXY_WHEELS_INDEX_URL}"
         GALAXY_CONDITIONAL_DEPENDENCIES=$(PYTHONPATH=lib python -c "import galaxy.dependencies; print '\n'.join(galaxy.dependencies.optional('$GALAXY_CONFIG_FILE'))")
         [ -z "$GALAXY_CONDITIONAL_DEPENDENCIES" ] || echo "$GALAXY_CONDITIONAL_DEPENDENCIES" | pip install -r /dev/stdin --index-url "${GALAXY_WHEELS_INDEX_URL}"
 fi
 
-if [ $NONUSE != *"load_python_optional_dependencies"*] && ["x$LOAD_PYTHON_DEV_DEPENDENCIES" != "x"]
+if [[ $NONUSE != *"load_python_optional_dependencies"* ]] && [[ "x$LOAD_PYTHON_DEV_DEPENDENCIES" != "x" ]]
     then
         echo "Installing development requirements in galaxy virtual environment..."
         : ${GALAXY_WHEELS_INDEX_URL:="https://wheels.galaxyproject.org/simple"}
         dev_requirements='./lib/galaxy/dependencies/dev-requirements.txt'
-        [ -f $dev_requirements ] && pip install -r $dev_requirements --index-url "${GALAXY_WHEELS_INDEX_URL}"
+        [ -f $dev_requirements ] && pip install -q -r $dev_requirements --index-url "${GALAXY_WHEELS_INDEX_URL}"
 fi
 
 # Enable Test Tool Shed

--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -113,7 +113,7 @@ python /usr/local/bin/export_user_files.py $PG_DATA_DIR_DEFAULT
 
 # Enable loading of dependencies on startup. Such as LDAP.
 # Adapted from galaxyproject/galaxy/scripts/common_startup.sh
-if [[ $NONUSE != *"load_python_optional_dependencies"* ]]
+if [[ "x$LOAD_GALAXY_CONDITIONAL_DEPENDENCIES" != "x" ]]
     then
         echo "Installing optional dependencies in galaxy virtual environment..."
         : ${GALAXY_WHEELS_INDEX_URL:="https://wheels.galaxyproject.org/simple"}
@@ -121,7 +121,7 @@ if [[ $NONUSE != *"load_python_optional_dependencies"* ]]
         [ -z "$GALAXY_CONDITIONAL_DEPENDENCIES" ] || echo "$GALAXY_CONDITIONAL_DEPENDENCIES" | pip install -q -r /dev/stdin --index-url "${GALAXY_WHEELS_INDEX_URL}"
 fi
 
-if [[ $NONUSE != *"load_python_optional_dependencies"* ]] && [[ "x$LOAD_PYTHON_DEV_DEPENDENCIES" != "x" ]]
+if [[ "x$LOAD_GALAXY_CONDITIONAL_DEPENDENCIES" != "x"  ]] && [[ "x$LOAD_PYTHON_DEV_DEPENDENCIES" != "x" ]]
     then
         echo "Installing development requirements in galaxy virtual environment..."
         : ${GALAXY_WHEELS_INDEX_URL:="https://wheels.galaxyproject.org/simple"}

--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -117,9 +117,8 @@ if [[ $NONUSE != *"load_python_optional_dependencies"* ]]
     then
         echo "Installing optional dependencies in galaxy virtual environment..."
         : ${GALAXY_WHEELS_INDEX_URL:="https://wheels.galaxyproject.org/simple"}
-        pip install -q -r requirements.txt --index-url "${GALAXY_WHEELS_INDEX_URL}"
         GALAXY_CONDITIONAL_DEPENDENCIES=$(PYTHONPATH=lib python -c "import galaxy.dependencies; print '\n'.join(galaxy.dependencies.optional('$GALAXY_CONFIG_FILE'))")
-        [ -z "$GALAXY_CONDITIONAL_DEPENDENCIES" ] || echo "$GALAXY_CONDITIONAL_DEPENDENCIES" | pip install -r /dev/stdin --index-url "${GALAXY_WHEELS_INDEX_URL}"
+        [ -z "$GALAXY_CONDITIONAL_DEPENDENCIES" ] || echo "$GALAXY_CONDITIONAL_DEPENDENCIES" | pip install -q -r /dev/stdin --index-url "${GALAXY_WHEELS_INDEX_URL}"
 fi
 
 if [[ $NONUSE != *"load_python_optional_dependencies"* ]] && [[ "x$LOAD_PYTHON_DEV_DEPENDENCIES" != "x" ]]

--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -113,7 +113,7 @@ python /usr/local/bin/export_user_files.py $PG_DATA_DIR_DEFAULT
 
 # Enable loading of dependencies on startup. Such as LDAP.
 # Adapted from galaxyproject/galaxy/scripts/common_startup.sh
-if [ "x$FETCH_WHEELS" != "x" ]
+if [[ $NONUSE != *"load_python_optional_dependencies"* ]]
     then
         echo "Installing optional dependencies "
         : ${GALAXY_WHEELS_INDEX_URL:="https://wheels.galaxyproject.org/simple"}
@@ -122,7 +122,7 @@ if [ "x$FETCH_WHEELS" != "x" ]
         [ -z "$GALAXY_CONDITIONAL_DEPENDENCIES" ] || echo "$GALAXY_CONDITIONAL_DEPENDENCIES" | pip install -r /dev/stdin --index-url "${GALAXY_WHEELS_INDEX_URL}"
 fi
 
-if [ "x$FETCH_WHEELS" != "x" -a "x$DEV_WHEELS" != "x" ]
+if [[ $NONUSE != *"load_python_optional_dependencies"* -a "x$LOAD_PYTHON_DEV_DEPENDENCIES" != "x"]]
     then
         echo "Installing development requirements "
         : ${GALAXY_WHEELS_INDEX_URL:="https://wheels.galaxyproject.org/simple"}

--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -115,7 +115,7 @@ python /usr/local/bin/export_user_files.py $PG_DATA_DIR_DEFAULT
 # Adapted from galaxyproject/galaxy/scripts/common_startup.sh
 if [[ $NONUSE != *"load_python_optional_dependencies"* ]]
     then
-        echo "Installing optional dependencies "
+        echo "Installing optional dependencies in galaxy virtual environment..."
         : ${GALAXY_WHEELS_INDEX_URL:="https://wheels.galaxyproject.org/simple"}
         pip install -r requirements.txt --index-url "${GALAXY_WHEELS_INDEX_URL}"
         GALAXY_CONDITIONAL_DEPENDENCIES=$(PYTHONPATH=lib python -c "import galaxy.dependencies; print '\n'.join(galaxy.dependencies.optional('$GALAXY_CONFIG_FILE'))")
@@ -124,7 +124,7 @@ fi
 
 if [[ $NONUSE != *"load_python_optional_dependencies"* -a "x$LOAD_PYTHON_DEV_DEPENDENCIES" != "x"]]
     then
-        echo "Installing development requirements "
+        echo "Installing development requirements in galaxy virtual environment..."
         : ${GALAXY_WHEELS_INDEX_URL:="https://wheels.galaxyproject.org/simple"}
         dev_requirements='./lib/galaxy/dependencies/dev-requirements.txt'
         [ -f $dev_requirements ] && pip install -r $dev_requirements --index-url "${GALAXY_WHEELS_INDEX_URL}"

--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -104,12 +104,21 @@ cd {{ galaxy_server_dir }}
 . {{ galaxy_venv_dir }}/bin/activate
 umount /var/lib/docker
 
+{% if startup_export_user_files is defined and startup_export_user_files|bool %}
+# If /export/ is mounted, export_user_files file moving all data to /export/
+# symlinks will point from the original location to the new path under /export/
+# If /export/ is not given, nothing will happen in that step
+python /usr/local/bin/export_user_files.py $PG_DATA_DIR_DEFAULT
+{% endif %}
+
+# Enable loading of dependencies on startup. Such as LDAP.
+# Adapted from galaxyproject/galaxy/scripts/common_startup.sh
 if [ "x$FETCH_WHEELS" != "x" ]
     then
         echo "Installing optional dependencies "
         : ${GALAXY_WHEELS_INDEX_URL:="https://wheels.galaxyproject.org/simple"}
         pip install -r requirements.txt --index-url "${GALAXY_WHEELS_INDEX_URL}"
-        GALAXY_CONDITIONAL_DEPENDENCIES=$(PYTHONPATH=lib python -c "import galaxy.dependencies; print '\n'.join(galaxy.dependencies.optional('{{galaxy_config_file}}'))")
+        GALAXY_CONDITIONAL_DEPENDENCIES=$(PYTHONPATH=lib python -c "import galaxy.dependencies; print '\n'.join(galaxy.dependencies.optional('$GALAXY_CONFIG_FILE'))")
         [ -z "$GALAXY_CONDITIONAL_DEPENDENCIES" ] || echo "$GALAXY_CONDITIONAL_DEPENDENCIES" | pip install -r /dev/stdin --index-url "${GALAXY_WHEELS_INDEX_URL}"
 fi
 
@@ -120,15 +129,6 @@ if [ "x$FETCH_WHEELS" != "x" -a "x$DEV_WHEELS" != "x" ]
         dev_requirements='./lib/galaxy/dependencies/dev-requirements.txt'
         [ -f $dev_requirements ] && pip install -r $dev_requirements --index-url "${GALAXY_WHEELS_INDEX_URL}"
 fi
-# Enable loading of dependencies on startup. Such as LDAP.
-# Adapted from galaxyproject/galaxy/scripts/common_startup.sh
-
-{% if startup_export_user_files is defined and startup_export_user_files|bool %}
-# If /export/ is mounted, export_user_files file moving all data to /export/
-# symlinks will point from the original location to the new path under /export/
-# If /export/ is not given, nothing will happen in that step
-python /usr/local/bin/export_user_files.py $PG_DATA_DIR_DEFAULT
-{% endif %}
 
 # Enable Test Tool Shed
 if [ "x$ENABLE_TTS_INSTALL" != "x" ]

--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -104,7 +104,7 @@ cd {{ galaxy_server_dir }}
 . {{ galaxy_venv_dir }}/bin/activate
 umount /var/lib/docker
 
-if [ "x"$FETCH_WHEELS" != "x" ]
+if [ "x$FETCH_WHEELS" != "x" ]
     then
         echo "Installing optional dependencies "
         : ${GALAXY_WHEELS_INDEX_URL:="https://wheels.galaxyproject.org/simple"}
@@ -113,7 +113,7 @@ if [ "x"$FETCH_WHEELS" != "x" ]
         [ -z "$GALAXY_CONDITIONAL_DEPENDENCIES" ] || echo "$GALAXY_CONDITIONAL_DEPENDENCIES" | pip install -r /dev/stdin --index-url "${GALAXY_WHEELS_INDEX_URL}"
 fi
 
-if [ "x"$FETCH_WHEELS" != "x" -a "x$DEV_WHEELS" != "x" ]
+if [ "x$FETCH_WHEELS" != "x" -a "x$DEV_WHEELS" != "x" ]
     then
         echo "Installing development requirements "
         : ${GALAXY_WHEELS_INDEX_URL:="https://wheels.galaxyproject.org/simple"}

--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -122,7 +122,7 @@ if [[ $NONUSE != *"load_python_optional_dependencies"* ]]
         [ -z "$GALAXY_CONDITIONAL_DEPENDENCIES" ] || echo "$GALAXY_CONDITIONAL_DEPENDENCIES" | pip install -r /dev/stdin --index-url "${GALAXY_WHEELS_INDEX_URL}"
 fi
 
-if [[ $NONUSE != *"load_python_optional_dependencies"* -a "x$LOAD_PYTHON_DEV_DEPENDENCIES" != "x"]]
+if [ $NONUSE != *"load_python_optional_dependencies"*] && ["x$LOAD_PYTHON_DEV_DEPENDENCIES" != "x"]
     then
         echo "Installing development requirements in galaxy virtual environment..."
         : ${GALAXY_WHEELS_INDEX_URL:="https://wheels.galaxyproject.org/simple"}

--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -104,6 +104,21 @@ cd {{ galaxy_server_dir }}
 . {{ galaxy_venv_dir }}/bin/activate
 umount /var/lib/docker
 
+if [ "x"$FETCH_WHEELS" != "x" ]; then
+    : ${GALAXY_WHEELS_INDEX_URL:="https://wheels.galaxyproject.org/simple"}
+    pip install -r requirements.txt --index-url "${GALAXY_WHEELS_INDEX_URL}"
+    GALAXY_CONDITIONAL_DEPENDENCIES=$(PYTHONPATH=lib python -c "import galaxy.dependencies; print '\n'.join(galaxy.dependencies.optional('{{galaxy_config_file}}'))")
+    [ -z "$GALAXY_CONDITIONAL_DEPENDENCIES" ] || echo "$GALAXY_CONDITIONAL_DEPENDENCIES" | pip install -r /dev/stdin --index-url "${GALAXY_WHEELS_INDEX_URL}"
+fi
+
+if [ "x"$FETCH_WHEELS" != "x" -a "x$DEV_WHEELS" != "x" ]; then
+    : ${GALAXY_WHEELS_INDEX_URL:="https://wheels.galaxyproject.org/simple"}
+    dev_requirements='./lib/galaxy/dependencies/dev-requirements.txt'
+    [ -f $dev_requirements ] && pip install -r $dev_requirements --index-url "${GALAXY_WHEELS_INDEX_URL}"
+fi
+# Enable loading of dependencies on startup. Such as LDAP.
+# Adapted from galaxyproject/galaxy/scripts/common_startup.sh
+
 {% if startup_export_user_files is defined and startup_export_user_files|bool %}
 # If /export/ is mounted, export_user_files file moving all data to /export/
 # symlinks will point from the original location to the new path under /export/

--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -104,17 +104,21 @@ cd {{ galaxy_server_dir }}
 . {{ galaxy_venv_dir }}/bin/activate
 umount /var/lib/docker
 
-if [ "x"$FETCH_WHEELS" != "x" ]; then
-    : ${GALAXY_WHEELS_INDEX_URL:="https://wheels.galaxyproject.org/simple"}
-    pip install -r requirements.txt --index-url "${GALAXY_WHEELS_INDEX_URL}"
-    GALAXY_CONDITIONAL_DEPENDENCIES=$(PYTHONPATH=lib python -c "import galaxy.dependencies; print '\n'.join(galaxy.dependencies.optional('{{galaxy_config_file}}'))")
-    [ -z "$GALAXY_CONDITIONAL_DEPENDENCIES" ] || echo "$GALAXY_CONDITIONAL_DEPENDENCIES" | pip install -r /dev/stdin --index-url "${GALAXY_WHEELS_INDEX_URL}"
+if [ "x"$FETCH_WHEELS" != "x" ]
+    then
+        echo "Installing optional dependencies "
+        : ${GALAXY_WHEELS_INDEX_URL:="https://wheels.galaxyproject.org/simple"}
+        pip install -r requirements.txt --index-url "${GALAXY_WHEELS_INDEX_URL}"
+        GALAXY_CONDITIONAL_DEPENDENCIES=$(PYTHONPATH=lib python -c "import galaxy.dependencies; print '\n'.join(galaxy.dependencies.optional('{{galaxy_config_file}}'))")
+        [ -z "$GALAXY_CONDITIONAL_DEPENDENCIES" ] || echo "$GALAXY_CONDITIONAL_DEPENDENCIES" | pip install -r /dev/stdin --index-url "${GALAXY_WHEELS_INDEX_URL}"
 fi
 
-if [ "x"$FETCH_WHEELS" != "x" -a "x$DEV_WHEELS" != "x" ]; then
-    : ${GALAXY_WHEELS_INDEX_URL:="https://wheels.galaxyproject.org/simple"}
-    dev_requirements='./lib/galaxy/dependencies/dev-requirements.txt'
-    [ -f $dev_requirements ] && pip install -r $dev_requirements --index-url "${GALAXY_WHEELS_INDEX_URL}"
+if [ "x"$FETCH_WHEELS" != "x" -a "x$DEV_WHEELS" != "x" ]
+    then
+        echo "Installing development requirements "
+        : ${GALAXY_WHEELS_INDEX_URL:="https://wheels.galaxyproject.org/simple"}
+        dev_requirements='./lib/galaxy/dependencies/dev-requirements.txt'
+        [ -f $dev_requirements ] && pip install -r $dev_requirements --index-url "${GALAXY_WHEELS_INDEX_URL}"
 fi
 # Enable loading of dependencies on startup. Such as LDAP.
 # Adapted from galaxyproject/galaxy/scripts/common_startup.sh

--- a/tests/conditional_deps/auth_conf.xml
+++ b/tests/conditional_deps/auth_conf.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<auth>
+    <authenticator>
+        <type>ldap</type>
+        <filter>'{email}'.endswith('example.com')</filter>
+        <options>
+            <allow-register>True</allow-register>
+            <auto-register>True</auto-register>
+            <allow-password-change>False</allow-password-change>
+
+            <server>ldap://dc1.example.com</server>
+            <login-use-username>True</login-use-username>
+            <continue-on-failure>False</continue-on-failure>
+
+            <search-fields>sAMAccountName,mail</search-fields>
+            <search-base>dc=dc1,dc=example,dc=com</search-base>
+
+            <search-filter>(&amp;(objectClass=user)(sAMAccountName={username}))</search-filter>
+
+            <search-user>ldapsearch@dc1.example.com</search-user>
+            <search-password>SECRETDON'tLoOK!1!</search-password>
+
+            <bind-user>{sAMAccountName}@dc1.example.com</bind-user>
+            <bind-password>{password}</bind-password>
+            <auto-register-username>{sAMAccountName}</auto-register-username>
+            <auto-register-email>{mail}</auto-register-email>
+
+        </options>
+    </authenticator>
+</auth>

--- a/tests/conditional_deps/test_script.sh
+++ b/tests/conditional_deps/test_script.sh
@@ -2,6 +2,7 @@
 echo "Starting container"
 CONTAINER_ID=`docker run -d \
 -e GALAXY_CONFIG_AUTH_CONFIG_FILE=config/auth_conf.xml \
+-e LOAD_GALAXY_CONDITIONAL_DEPENDENCIES=True \
 -v $PWD/tests/conditional_deps/auth_conf.xml:/galaxy-central/config/auth_conf.xml \
 galaxy-docker/test`
 docker ps

--- a/tests/conditional_deps/test_script.sh
+++ b/tests/conditional_deps/test_script.sh
@@ -1,21 +1,20 @@
 #!/bin/bash
 echo "Starting container"
-docker run -d -p 8080:80 -p 8021:21 -p 8022:22 \
+CONTAINER_ID=`docker run -d \
 -e GALAXY_CONFIG_AUTH_CONFIG_FILE=config/auth_conf.xml \
 -v $PWD/tests/conditional_deps/auth_conf.xml:/galaxy-central/config/auth_conf.xml \
---name galaxy-test \
-galaxy-docker/test
+galaxy-docker/test`
 docker ps
 echo "Waiting for container to load..."
 sleep 30
 echo "Check auth_conf.xml's presence"
-docker exec -u 1450 galaxy-test cat /galaxy-central/config/auth_conf.xml
+docker exec -u 1450 $CONTAINER_ID cat /galaxy-central/config/auth_conf.xml
 echo "Wait some more for the dependency to install"
 sleep 30
 echo "Testing presence of conditional dependency in virtual environment..."
-docker exec -u 1450 galaxy-test \
-/galaxy_venv/bin/pip list --format=columns | grep python-ldap
-if [$? == 0 ]
-  then echo "Conditional dependency loaded."
-  else echo "Conditional dependency not loaded!" && exit 1
+ldap_installed=`docker exec -u 1450 $CONTAINER_ID  \
+/galaxy_venv/bin/pip list --format=columns | grep python-ldap | wc -l`
+if [ $ldap_installed == 0 ]
+  then echo "Conditional dependency not loaded!" && exit 1
+  else echo "Conditional dependency loaded."
 fi

--- a/tests/conditional_deps/test_script.sh
+++ b/tests/conditional_deps/test_script.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 echo "Starting container"
 docker run -d -p 8080:80 -p 8021:21 -p 8022:22 \
---name galaxy_test_container \
 -e GALAXY_CONFIG_AUTH_CONFIG_FILE=config/auth_conf.xml \
 -v $PWD/tests/conditional_deps/auth_conf.xml:/galaxy-central/config/auth_conf.xml \
 --name galaxy-test \
@@ -10,11 +9,11 @@ docker ps
 echo "Waiting for container to load..."
 sleep 30
 echo "Check auth_conf.xml's presence"
-docker exec -u 1450 galaxy_test_container cat /galaxy-central/config/auth_conf.xml
+docker exec -u 1450 galaxy-test cat /galaxy-central/config/auth_conf.xml
 echo "Wait some more for the dependency to install"
 sleep 30
 echo "Testing presence of conditional dependency in virtual environment..."
-docker exec -u 1450 galaxy_test_container \
+docker exec -u 1450 galaxy-test \
 /galaxy_venv/bin/pip list --format=columns | grep python-ldap
 if [$? == 0 ]
   then echo "Conditional dependency loaded."

--- a/tests/conditional_deps/test_script.sh
+++ b/tests/conditional_deps/test_script.sh
@@ -3,7 +3,7 @@ echo "Starting container"
 docker run -d -p 8080:80 -p 8021:21 -p 8022:22 \
 --name galaxy_test_container \
 -e GALAXY_CONFIG_AUTH_CONFIG_FILE=config/auth_conf.xml \
--v tests/conditional_deps/auth_conf.xml:/galaxy-central/config/auth_conf.xml \
+-v $PWD/tests/conditional_deps/auth_conf.xml:/galaxy-central/config/auth_conf.xml \
 --name galaxy-test \
 galaxy-docker/test
 docker ps

--- a/tests/conditional_deps/test_script.sh
+++ b/tests/conditional_deps/test_script.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+echo "Starting container"
 docker run -d -p 8080:80 -p 8021:21 -p 8022:22 \
 --name galaxy_test_container \
 -e GALAXY_CONFIG_AUTH_CONFIG_FILE=config/auth_conf.xml \
@@ -6,10 +7,12 @@ docker run -d -p 8080:80 -p 8021:21 -p 8022:22 \
 --name galaxy-test \
 galaxy-docker/test
 docker ps
+echo "Waiting for container to load..."
 sleep 30
+echo "Testing presence of conditional dependency in virtual environment..."
 docker exec -u 1450 galaxy-test \
 /galaxy_venv/bin/pip list --format=columns | grep python-ldap
 if [$? == 0 ]
-  then echo "Conditional dependency loaded"
+  then echo "Conditional dependency loaded."
   else echo "Conditional dependency not loaded!" && exit 1
 fi

--- a/tests/conditional_deps/test_script.sh
+++ b/tests/conditional_deps/test_script.sh
@@ -9,6 +9,10 @@ galaxy-docker/test
 docker ps
 echo "Waiting for container to load..."
 sleep 30
+echo "Check auth_conf.xml's presence"
+docker exec -u 1450 galaxy-test cat /galaxy-central/config/auth_conf.xml
+echo "Wait some more for the dependency to install"
+sleep 60
 echo "Testing presence of conditional dependency in virtual environment..."
 docker exec -u 1450 galaxy-test \
 /galaxy_venv/bin/pip list --format=columns | grep python-ldap

--- a/tests/conditional_deps/test_script.sh
+++ b/tests/conditional_deps/test_script.sh
@@ -5,16 +5,16 @@ docker run -d -p 8080:80 -p 8021:21 -p 8022:22 \
 -e GALAXY_CONFIG_AUTH_CONFIG_FILE=config/auth_conf.xml \
 -v $PWD/tests/conditional_deps/auth_conf.xml:/galaxy-central/config/auth_conf.xml \
 --name galaxy-test \
-galaxy-docker/test /usr/bin/startup
+galaxy-docker/test
 docker ps
 echo "Waiting for container to load..."
-sleep 60
+sleep 30
 echo "Check auth_conf.xml's presence"
-docker exec -u 1450 galaxy-test cat /galaxy-central/config/auth_conf.xml
+docker exec -u 1450 galaxy_test_container cat /galaxy-central/config/auth_conf.xml
 echo "Wait some more for the dependency to install"
-sleep 60
+sleep 30
 echo "Testing presence of conditional dependency in virtual environment..."
-docker exec -u 1450 galaxy-test \
+docker exec -u 1450 galaxy_test_container \
 /galaxy_venv/bin/pip list --format=columns | grep python-ldap
 if [$? == 0 ]
   then echo "Conditional dependency loaded."

--- a/tests/conditional_deps/test_script.sh
+++ b/tests/conditional_deps/test_script.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+docker run -d -p 8080:80 -p 8021:21 -p 8022:22 \
+--name galaxy_test_container \
+-e GALAXY_CONFIG_AUTH_CONFIG_FILE=config/auth_conf.xml \
+-v tests/conditional_deps/auth_conf.xml:/galaxy-central/config/auth_conf.xml \
+--name galaxy-test \
+galaxy-docker/test
+docker ps
+sleep 30
+docker exec -u 1450 galaxy-test \
+/galaxy_venv/bin/pip list --format=columns | grep python-ldap
+if [$? == 0 ]
+  then echo "Conditional dependency loaded"
+  else echo "Conditional dependency not loaded!" && exit 1
+fi

--- a/tests/conditional_deps/test_script.sh
+++ b/tests/conditional_deps/test_script.sh
@@ -5,7 +5,7 @@ docker run -d -p 8080:80 -p 8021:21 -p 8022:22 \
 -e GALAXY_CONFIG_AUTH_CONFIG_FILE=config/auth_conf.xml \
 -v $PWD/tests/conditional_deps/auth_conf.xml:/galaxy-central/config/auth_conf.xml \
 --name galaxy-test \
-galaxy-docker/test
+galaxy-docker/test /usr/bin/startup
 docker ps
 echo "Waiting for container to load..."
 sleep 60

--- a/tests/conditional_deps/test_script.sh
+++ b/tests/conditional_deps/test_script.sh
@@ -8,7 +8,7 @@ docker run -d -p 8080:80 -p 8021:21 -p 8022:22 \
 galaxy-docker/test
 docker ps
 echo "Waiting for container to load..."
-sleep 30
+sleep 60
 echo "Check auth_conf.xml's presence"
 docker exec -u 1450 galaxy-test cat /galaxy-central/config/auth_conf.xml
 echo "Wait some more for the dependency to install"


### PR DESCRIPTION
Plain galaxy starts using [common_startup.sh](https://github.com/galaxyproject/galaxy/blob/dev/scripts/common_startup.sh) which loads conditional requirements. For example if you have specified an auth_con.xml file in galaxy.ini it will load the python-ldap package. 
Unfortunately this feature was not present in docker-galaxy-stable. 
I copied the responsible script in common_startup.sh to startup.sh.j2 and tested it in the docker image by trying to authenticate on our own ldap server. 
It seems to work. All that required is that the FETCH_WHEELS environment variable is set to something other than "". If further modifications need to be made to properly integrate this please let me know.