### PR TITLE
Add uuidgen

### DIFF
--- a/tasks/cvmfs_client.yml
+++ b/tasks/cvmfs_client.yml
@@ -6,8 +6,8 @@
 - name: Install autofs system package
   apt: pkg=pkg={{ item }} state={{ galaxy_extras_apt_package_state }}
   with_items:
-	    - autofs
-	    - uuid-runtime
+    - autofs
+    - uuid-runtime
   when: galaxy_extras_install_packages
 
 

--- a/tasks/cvmfs_client.yml
+++ b/tasks/cvmfs_client.yml
@@ -4,8 +4,12 @@
 
 # Install autofs
 - name: Install autofs system package
-  apt: pkg=autofs state={{ galaxy_extras_apt_package_state }}
+  apt: pkg=pkg={{ item }} state={{ galaxy_extras_apt_package_state }}
+  with_items:
+	    - autofs
+	    - uuid-runtime
   when: galaxy_extras_install_packages
+
 
 - name: Remove autofs service file since we're using Supervisor
   file:


### PR DESCRIPTION
I see the following warning (?) in my logs with the new cvmfs setup. It seems to work without. Anyone knows if this is strictly needed?
```
root@92346ba6f12d:/galaxy-central# cvmfs_config chksetup
/usr/bin/cvmfs_config: line 578: uuidgen: command not found
OK
```

ping @afgane 