### PR TITLE
Move CVMFS setup before supervisor

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,6 +48,11 @@
   tags:
    - condor
 
+- include: cvmfs_client.yml
+  when: galaxy_extras_config_cvmfs
+  tags:
+   - cvmfs
+   
 - include: supervisor.yml
   when: galaxy_extras_config_supervisor
   tags:
@@ -72,8 +77,3 @@
   when: galaxy_extras_config_startup
   tags:
    - startup
-
-- include: cvmfs_client.yml
-  when: galaxy_extras_config_cvmfs
-  tags:
-   - cvmfs


### PR DESCRIPTION
Otherwise, Supervisor reports `can't find command '/usr/sbin/automount'`

Should address https://github.com/galaxyproject/ansible-galaxy-extras/issues/164
If the supervisor process status is still `FATAL` at the end of a build, it always clears for me after a reboot.