### PR TITLE
added installation of conditional dependencies

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,7 @@ galaxy_extras_config_condor_docker: false
 galaxy_extras_config_k8_jobs: false
 galaxy_extras_config_supervisor: true
 galaxy_extras_config_galaxy_root: true
+galaxy_extras_config_galaxy_extra_dependencies: true
 galaxy_extras_config_galaxy_job_metrics: true
 galaxy_extras_config_uwsgi: true
 galaxy_extras_config_ie_proxy: true
@@ -22,7 +23,7 @@ galaxy_extras_config_ssl_method: self-signed  # This may be 'own', 'self-signed'
 galaxy_extras_galaxy_domain: "localhost"  # This is used by letsencrypt, set it to the domain name under which galaxy can be reached
 galaxy_extras_config_startup: true
 galaxy_extras_config_rabbitmq: false
-galaxy_extras_config_cvmfs: true 
+galaxy_extras_config_cvmfs: true
 
 # Default destination for Galaxy jobs in generated job_conf.xml - can
 # tweak this to allow for a different default for Docker-enabled tools.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,7 +12,7 @@ galaxy_extras_config_condor_docker: false
 galaxy_extras_config_k8_jobs: false
 galaxy_extras_config_supervisor: true
 galaxy_extras_config_galaxy_root: true
-galaxy_extras_config_galaxy_extra_dependencies: true
+galaxy_extras_config_galaxy_extra_dependencies: false
 galaxy_extras_config_galaxy_job_metrics: true
 galaxy_extras_config_uwsgi: true
 galaxy_extras_config_ie_proxy: true

--- a/tasks/galaxy_extra_dependencies.yml
+++ b/tasks/galaxy_extra_dependencies.yml
@@ -1,0 +1,23 @@
+- name: "Install most of the conditional dependencies"
+  # https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/dependencies/conditional-requirements.txt
+  pip:
+    name: "{{item}}"
+    virtualenv: "{{ galaxy_venv_dir }}"
+    virtualenv_command: "{{ pip_virtualenv_command | default( 'virtualenv' ) }}"
+    extra_args: --index-url https://wheels.galaxyproject.org/simple
+  become: True
+  become_user: "{{ galaxy_user_name }}"
+  with_items:
+    - "psycopg2==2.6.1"
+    - "WebError==0.10.3"
+    - "Pygments==2.0.2"
+    - "python-openid"
+    - "fluent-logger"
+    - "raven"
+    - "drmaa"
+    - "statsd"
+    - "graphitesend"
+    - "python-ldap==2.4.27"
+    - "kamaki"
+    - "azure-storage==0.32.0"
+    - "watchdog"

--- a/tasks/galaxy_extra_dependencies.yml
+++ b/tasks/galaxy_extra_dependencies.yml
@@ -20,4 +20,3 @@
     - "python-ldap==2.4.27"
     - "kamaki"
     - "azure-storage==0.32.0"
-    - "watchdog"

--- a/tasks/galaxy_root.yml
+++ b/tasks/galaxy_root.yml
@@ -8,5 +8,14 @@
   become: True
   become_user: "{{ galaxy_user_name }}"
 
+- name: "Install watchdog for galaxy"
+  pip:
+    name: "watchdog"
+    virtualenv: "{{ galaxy_venv_dir }}"
+    virtualenv_command: "{{ pip_virtualenv_command | default( 'virtualenv' ) }}"
+    extra_args: --index-url https://wheels.galaxyproject.org/simple
+  become: True
+  become_user: "{{ galaxy_user_name }}"
+
 - name: Ensure galaxy_log dir exists
   file: path={{ galaxy_log_dir }} state=directory owner={{ galaxy_user_name }} group={{ galaxy_user_name }}

--- a/tasks/galaxy_root.yml
+++ b/tasks/galaxy_root.yml
@@ -8,10 +8,29 @@
   become: True
   become_user: "{{ galaxy_user_name }}"
 
-- name: "Install watchdog for galaxy"
-  pip: name=watchdog virtualenv={{ galaxy_venv_dir }} virtualenv_command="{{ pip_virtualenv_command | default( 'virtualenv' ) }}"
+- name: "Install most of the conditional dependencies including watchdog"
+  # https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/dependencies/conditional-requirements.txt
+  pip:
+    name: "{{item}}"
+    virtualenv: {{ galaxy_venv_dir }}
+    virtualenv_command: "{{ pip_virtualenv_command | default( 'virtualenv' ) }}"
+    extra_args: --index-url https://wheels.galaxyproject.org/simple
   become: True
   become_user: "{{ galaxy_user_name }}"
+  with_items:
+    - "psycopg2==2.6.1"
+    - "WebError==0.10.3"
+    - "Pygments==2.0.2"
+    - "python-openid"
+    - "fluent-logger"
+    - "raven"
+    - "drmaa"
+    - "statsd"
+    - "graphitesend"
+    - "python-ldap==2.4.27"
+    - "kamaki"
+    - "azure-storage==0.32.0"
+    - "watchdog"
 
 - name: Ensure galaxy_log dir exists
   file: path={{ galaxy_log_dir }} state=directory owner={{ galaxy_user_name }} group={{ galaxy_user_name }}

--- a/tasks/galaxy_root.yml
+++ b/tasks/galaxy_root.yml
@@ -12,7 +12,7 @@
   # https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/dependencies/conditional-requirements.txt
   pip:
     name: "{{item}}"
-    virtualenv: {{ galaxy_venv_dir }}
+    virtualenv: "{{ galaxy_venv_dir }}"
     virtualenv_command: "{{ pip_virtualenv_command | default( 'virtualenv' ) }}"
     extra_args: --index-url https://wheels.galaxyproject.org/simple
   become: True

--- a/tasks/galaxy_root.yml
+++ b/tasks/galaxy_root.yml
@@ -8,29 +8,5 @@
   become: True
   become_user: "{{ galaxy_user_name }}"
 
-- name: "Install most of the conditional dependencies including watchdog"
-  # https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/dependencies/conditional-requirements.txt
-  pip:
-    name: "{{item}}"
-    virtualenv: "{{ galaxy_venv_dir }}"
-    virtualenv_command: "{{ pip_virtualenv_command | default( 'virtualenv' ) }}"
-    extra_args: --index-url https://wheels.galaxyproject.org/simple
-  become: True
-  become_user: "{{ galaxy_user_name }}"
-  with_items:
-    - "psycopg2==2.6.1"
-    - "WebError==0.10.3"
-    - "Pygments==2.0.2"
-    - "python-openid"
-    - "fluent-logger"
-    - "raven"
-    - "drmaa"
-    - "statsd"
-    - "graphitesend"
-    - "python-ldap==2.4.27"
-    - "kamaki"
-    - "azure-storage==0.32.0"
-    - "watchdog"
-
 - name: Ensure galaxy_log dir exists
   file: path={{ galaxy_log_dir }} state=directory owner={{ galaxy_user_name }} group={{ galaxy_user_name }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,11 @@
   tags:
    - metrics
 
+- include: galaxy_extra_dependencies.yml
+  when: galaxy_extras_config_galaxy_extra_dependencies
+  tags:
+   - extra_dependencies
+
 - include: uwsgi.yml
   when: galaxy_extras_config_uwsgi
   tags:
@@ -52,7 +57,7 @@
   when: galaxy_extras_config_cvmfs
   tags:
    - cvmfs
-   
+
 - include: supervisor.yml
   when: galaxy_extras_config_supervisor
   tags:


### PR DESCRIPTION
This is mainly important for the docker-galaxy-stable image. It will have ldap and other python dependencies installed by default if this request is pulled. We could drop some of the dependencies to save space and let the startup script of #161 handle that in case someone needs an exotic dependency.