### PR TITLE
Add IU and TACC servers to cvmfs_server_urls

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -281,7 +281,7 @@ cvmfs_keys:
 cvmfs_server_urls:
   - domain: galaxyproject.org
     urls:
-      - "http://cvmfs1-psu0.galaxyproject.org/cvmfs/@fqrn@"
+      - "http://cvmfs1-iu0.galaxyproject.org/cvmfs/@fqrn@;http://cvmfs1-tacc0.galaxyproject.org/cvmfs/@fqrn@;http://cvmfs1-psu0.galaxyproject.org/cvmfs/@fqrn@"
 
 cvmfs_repositories:
   - repository: data.galaxyproject.org


### PR DESCRIPTION
PSU server is down at the moment, adding all servers should improve robustness (when I developed this I mistakenly thought that each server was responsible for one repository (test, main, data) of the galaxyproject.org set).