### PR TITLE
fix for hard-coded uwsgi ansible variable uwsgi_port

### DIFF
--- a/templates/supervisor.conf.j2
+++ b/templates/supervisor.conf.j2
@@ -102,9 +102,9 @@ priority        = 200
 [program:galaxy_web]
 {% if galaxy_uwsgi|bool %}
 {% if galaxy_uwsgi_static_conf|bool %}
-command         = {{ galaxy_venv_dir }}/bin/uwsgi --virtualenv {{ galaxy_venv_dir }} --ini-paste {{ galaxy_config_file }} --logdate --master --processes {{ galaxy_web_processes }} --threads {{ uwsgi_threads }} --logto {{ uwsgi_log }} --socket 127.0.0.1:4001 --pythonpath lib --stats 127.0.0.1:9191 -b 16384
+command         = {{ galaxy_venv_dir }}/bin/uwsgi --virtualenv {{ galaxy_venv_dir }} --ini-paste {{ galaxy_config_file }} --logdate --master --processes {{ galaxy_web_processes }} --threads {{ uwsgi_threads }} --logto {{ uwsgi_log }} --socket 127.0.0.1:{{ uwsgi_port }} --pythonpath lib --stats 127.0.0.1:9191 -b 16384
 {% else %}
-command         = {{ galaxy_venv_dir }}/bin/uwsgi --virtualenv {{ galaxy_venv_dir }} --ini-paste {{ galaxy_config_file }} --logdate --master --processes %(ENV_UWSGI_PROCESSES)s --threads %(ENV_UWSGI_THREADS)s --logto {{ uwsgi_log }} --socket 127.0.0.1:4001 --pythonpath lib --stats 127.0.0.1:9191 -b 16384
+command         = {{ galaxy_venv_dir }}/bin/uwsgi --virtualenv {{ galaxy_venv_dir }} --ini-paste {{ galaxy_config_file }} --logdate --master --processes %(ENV_UWSGI_PROCESSES)s --threads %(ENV_UWSGI_THREADS)s --logto {{ uwsgi_log }} --socket 127.0.0.1:{{ uwsgi_port }} --pythonpath lib --stats 127.0.0.1:9191 -b 16384
 {% endif %}
 directory       = {{ galaxy_server_dir }}
 umask           = 022


### PR DESCRIPTION
Hello; this is a fix for a situation where a user [specifies their own uwsgi_port in this role's default variables](https://github.com/galaxyproject/ansible-galaxy-extras/blob/7ab0cad82e71ed71678aa0443b5c7d9808439ed4/defaults/main.yml#L120). 

Port 4001 was hardcoded into the `supervisor.conf` template, so galaxy_web uwsgi instances were listening on that port, however `nginx.conf` [correctly picked up the new port](https://github.com/galaxyproject/ansible-galaxy-extras/blob/4b6344450ccd50d0b26806f3e0c1ed39b45aaeee/templates/nginx_uwsgi.conf.j2#L3) and was `proxy_pass`ing requests to the specified port.

With this minor alteration, nginx and uwsgi once again have a harmonious relationship.

*note: i wasn't able to find any other places where the port was hard-coded in, or any other hard-coded ports that could benefit from being turned in to variables, but am happy to make those alterations if there are some i've missed*