### PR TITLE
Sets version for pykube library to 0.15.0 for k8s stability

### DIFF
--- a/tasks/k8.yml
+++ b/tasks/k8.yml
@@ -12,6 +12,6 @@
   become_user: "{{ galaxy_user_name }}"
 
 - name: "Install pykube for galaxy"
-  pip: name=pykube virtualenv={{ galaxy_venv_dir }} virtualenv_command="{{ pip_virtualenv_command | default( 'virtualenv' ) }}"
+  pip: name=pykube version="0.15.0" virtualenv={{ galaxy_venv_dir }} virtualenv_command="{{ pip_virtualenv_command | default( 'virtualenv' ) }}"
   become: True
   become_user: "{{ galaxy_user_name }}"


### PR DESCRIPTION
This sets the version of pykube to 0.15.0, for stability of the k8s integration. As discussed in https://github.com/galaxyproject/galaxy-kubernetes/issues/2#issuecomment-336390996