### PR TITLE
Initial defaults for missing k8s plugin vars

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -131,9 +131,14 @@ galaxy_web_processes: 2
 galaxy_handler_processes: 2
 
 # Follow job_conf attributes set if galaxy_extras_config_k8_jobs is true.
-galaxy_k8_jobs_use_service_account: true
-galaxy_k8_jobs_persistent_volume_claim_name: galaxy-web-claim0
-galaxy_k8_jobs_persistent_volume_claim_mount_path: /export
+galaxy_k8s_jobs_use_service_account: true
+galaxy_k8s_jobs_persistent_volume_claim_name: galaxy-web-claim0
+galaxy_k8s_jobs_persistent_volume_claim_mount_path: /export
+galaxy_k8s_jobs_namespace: default
+galaxy_k8s_jobs_supplemental_group_id: 0
+galaxy_k8s_jobs_fs_group_id: 0
+galaxy_k8s_jobs_pull_policy: IfNotPresent
+galaxy_k8s_jobs_pods_retrials: 1
 
 startup_export_user_files: true
 startup_chown_on_directory: ""

--- a/templates/job_conf.xml.j2
+++ b/templates/job_conf.xml.j2
@@ -31,6 +31,11 @@
             <param id="k8s_use_service_account">true</param>
             <param id="k8s_persistent_volume_claim_name">galaxy-web-claim0</param>
             <param id="k8s_persistent_volume_claim_mount_path">/export</param>
+            <param id="k8s_namespace">default</param>
+            <param id="k8s_supplemental_group_id">0</param>
+            <param id="k8s_fs_group_id">0</param>
+            <param id="k8s_pull_policy">IfNotPresent</param>
+            <param id="k8s_pod_retrials">1</param
 {% if galaxy_minimum_version >= "17.09" %}
             <param id="enabled" from_environ="GALAXY_RUNNERS_ENABLE_K8">true</param>
 {% endif %}

--- a/templates/job_conf.xml.j2
+++ b/templates/job_conf.xml.j2
@@ -28,14 +28,14 @@
 {% if galaxy_extras_config_k8_jobs %}
         <plugin id="k8" type="runner" load="galaxy.jobs.runners.kubernetes:KubernetesJobRunner">
             <!-- We are inside of Kubernetes so use this. -->
-            <param id="k8s_use_service_account">{{ use_service_account }}</param>
-            <param id="k8s_persistent_volume_claim_name">{{ galaxy_k8s_jobs_persistent_volume_claim_name }}</param>
-            <param id="k8s_persistent_volume_claim_mount_path">{{ galaxy_k8s_jobs_persistent_volume_claim_mount_path }}</param>
-            <param id="k8s_namespace">{{ galaxy_k8s_jobs_namespace }}</param>
-            <param id="k8s_supplemental_group_id">{{ galaxy_k8s_jobs_supplemental_group_id }}</param>
-            <param id="k8s_fs_group_id">{{ galaxy_k8s_jobs_fs_group_id }}</param>
-            <param id="k8s_pull_policy">{{ galaxy_k8s_jobs_pull_policy }}</param>
-            <param id="k8s_pod_retrials">{{ galaxy_k8s_jobs_pods_retrials }}</param
+            <param id="k8s_use_service_account" from_environ="GALAXY_RUNNERS_K8S_USE_SERVICE_ACCOUNT">{{ use_service_account }}</param>
+            <param id="k8s_persistent_volume_claim_name" from_environ="GALAXY_RUNNERS_K8S_PVC_NAME">{{ galaxy_k8s_jobs_persistent_volume_claim_name }}</param>
+            <param id="k8s_persistent_volume_claim_mount_path" from_environ="GALAXY_RUNNERS_K8S_PVC_MOUNT_PATH">{{ galaxy_k8s_jobs_persistent_volume_claim_mount_path }}</param>
+            <param id="k8s_namespace" from_environ="GALAXY_RUNNERS_K8S_NAMESPACE">{{ galaxy_k8s_jobs_namespace }}</param>
+            <param id="k8s_supplemental_group_id" from_environ="GALAXY_RUNNERS_K8S_SUPP_GROUP_ID">{{ galaxy_k8s_jobs_supplemental_group_id }}</param>
+            <param id="k8s_fs_group_id" from_environ="GALAXY_RUNNERS_K8S_FS_GROUP_ID">{{ galaxy_k8s_jobs_fs_group_id }}</param>
+            <param id="k8s_pull_policy" from_environ="GALAXY_RUNNERS_K8S_PULL_POLICY">{{ galaxy_k8s_jobs_pull_policy }}</param>
+            <param id="k8s_pod_retrials" from_environ="GALAXY_RUNNERS_K8S_POD_RETRIALS">{{ galaxy_k8s_jobs_pods_retrials }}</param
 {% if galaxy_minimum_version >= "17.09" %}
             <param id="enabled" from_environ="GALAXY_RUNNERS_ENABLE_K8">true</param>
 {% endif %}

--- a/templates/job_conf.xml.j2
+++ b/templates/job_conf.xml.j2
@@ -28,14 +28,14 @@
 {% if galaxy_extras_config_k8_jobs %}
         <plugin id="k8" type="runner" load="galaxy.jobs.runners.kubernetes:KubernetesJobRunner">
             <!-- We are inside of Kubernetes so use this. -->
-            <param id="k8s_use_service_account">true</param>
-            <param id="k8s_persistent_volume_claim_name">galaxy-web-claim0</param>
-            <param id="k8s_persistent_volume_claim_mount_path">/export</param>
-            <param id="k8s_namespace">default</param>
-            <param id="k8s_supplemental_group_id">0</param>
-            <param id="k8s_fs_group_id">0</param>
-            <param id="k8s_pull_policy">IfNotPresent</param>
-            <param id="k8s_pod_retrials">1</param
+            <param id="k8s_use_service_account">{{ use_service_account }}</param>
+            <param id="k8s_persistent_volume_claim_name">{{ galaxy_k8s_jobs_persistent_volume_claim_name }}</param>
+            <param id="k8s_persistent_volume_claim_mount_path">{{ galaxy_k8s_jobs_persistent_volume_claim_mount_path }}</param>
+            <param id="k8s_namespace">{{ galaxy_k8s_jobs_namespace }}</param>
+            <param id="k8s_supplemental_group_id">{{ galaxy_k8s_jobs_supplemental_group_id }}</param>
+            <param id="k8s_fs_group_id">{{ galaxy_k8s_jobs_fs_group_id }}</param>
+            <param id="k8s_pull_policy">{{ galaxy_k8s_jobs_pull_policy }}</param>
+            <param id="k8s_pod_retrials">{{ galaxy_k8s_jobs_pods_retrials }}</param
 {% if galaxy_minimum_version >= "17.09" %}
             <param id="enabled" from_environ="GALAXY_RUNNERS_ENABLE_K8">true</param>
 {% endif %}

--- a/templates/job_conf.xml.j2
+++ b/templates/job_conf.xml.j2
@@ -29,10 +29,10 @@
         <plugin id="k8" type="runner" load="galaxy.jobs.runners.kubernetes:KubernetesJobRunner">
             <!-- We are inside of Kubernetes so use this. -->
             <param id="k8s_use_service_account" from_environ="GALAXY_RUNNERS_K8S_USE_SERVICE_ACCOUNT">{{ use_service_account }}</param>
-            <param id="k8s_persistent_volume_claim_name" from_environ="GALAXY_RUNNERS_K8S_PVC_NAME">{{ galaxy_k8s_jobs_persistent_volume_claim_name }}</param>
-            <param id="k8s_persistent_volume_claim_mount_path" from_environ="GALAXY_RUNNERS_K8S_PVC_MOUNT_PATH">{{ galaxy_k8s_jobs_persistent_volume_claim_mount_path }}</param>
+            <param id="k8s_persistent_volume_claim_name" from_environ="GALAXY_RUNNERS_K8S_PERSISTENT_VOLUME_CLAIM_NAME">{{ galaxy_k8s_jobs_persistent_volume_claim_name }}</param>
+            <param id="k8s_persistent_volume_claim_mount_path" from_environ="GALAXY_RUNNERS_K8S_PERSISTENT_VOLUME_CLAIM_MOUNT_PATH">{{ galaxy_k8s_jobs_persistent_volume_claim_mount_path }}</param>
             <param id="k8s_namespace" from_environ="GALAXY_RUNNERS_K8S_NAMESPACE">{{ galaxy_k8s_jobs_namespace }}</param>
-            <param id="k8s_supplemental_group_id" from_environ="GALAXY_RUNNERS_K8S_SUPP_GROUP_ID">{{ galaxy_k8s_jobs_supplemental_group_id }}</param>
+            <param id="k8s_supplemental_group_id" from_environ="GALAXY_RUNNERS_K8S_SUPPLEMENTAL_GROUP_ID">{{ galaxy_k8s_jobs_supplemental_group_id }}</param>
             <param id="k8s_fs_group_id" from_environ="GALAXY_RUNNERS_K8S_FS_GROUP_ID">{{ galaxy_k8s_jobs_fs_group_id }}</param>
             <param id="k8s_pull_policy" from_environ="GALAXY_RUNNERS_K8S_PULL_POLICY">{{ galaxy_k8s_jobs_pull_policy }}</param>
             <param id="k8s_pod_retrials" from_environ="GALAXY_RUNNERS_K8S_POD_RETRIALS">{{ galaxy_k8s_jobs_pods_retrials }}</param


### PR DESCRIPTION
This PR adds some missing k8s plugin vars. As discussed in https://github.com/galaxyproject/galaxy-kubernetes/issues/2#issuecomment-336390996 .

Not sure if this might break something on older galaxy versions were the k8s runner wasn't aware of these additional vars. Please advise.