### PR TITLE
Adjust proftpd.conf.j2 variables

### DIFF
--- a/templates/proftpd.conf.j2
+++ b/templates/proftpd.conf.j2
@@ -73,14 +73,14 @@ SQLDefaultHomedir               /var/opt/local/proftpd
 SQLUserInfo                     custom:/LookupGalaxyUser
 {% if proftpd_sql_auth_type == "SHA1" %}
 
-SQLNamedQuery                   LookupGalaxyUser SELECT "email,password,'%{env:GALAXY_UID}','%{env:GALAXY_GID}','{{ proftpd_files_dir }}/%U','/bin/bash' FROM galaxy_user WHERE email='%U'"
+SQLNamedQuery                   LookupGalaxyUser SELECT "email,password,"{{ galaxy_user_uid }}","{{ galaxy_user_gid }}",'{{ proftpd_files_dir }}/%U','/bin/bash' FROM galaxy_user WHERE email='%U'"
 
 {% elif proftpd_sql_auth_type == "PBKDF2" %}
 
-SQLNamedQuery                   LookupGalaxyUser SELECT "email, (CASE WHEN substring(password from 1 for 6) = 'PBKDF2' THEN substring(password from 38 for 69) ELSE password END) AS password2,512,512,'{{ proftpd_files_dir }}/%U','/bin/bash' FROM galaxy_user WHERE email='%U'"
+SQLNamedQuery                   LookupGalaxyUser SELECT "email, (CASE WHEN substring(password from 1 for 6) = 'PBKDF2' THEN substring(password from 38 for 69) ELSE password END) AS password2,"{{ galaxy_user_uid }}","{{ galaxy_user_gid }}",'{{ proftpd_files_dir }}/%U','/bin/bash' FROM galaxy_user WHERE email='%U'"
 SQLNamedQuery                   GetUserSalt SELECT "(CASE WHEN SUBSTRING (password from 1 for 6) = 'PBKDF2' THEN SUBSTRING (password from 21 for 16) END) AS salt FROM galaxy_user WHERE email='%U'"
-SQLDefaultGID                   %{env:GALAXY_GID}
-SQLDefaultUID                   %{env:GALAXY_UID}
+SQLDefaultGID                   {{ galaxy_user_gid }}
+SQLDefaultUID                   {{ galaxy_user_uid }}
 SQLPasswordPBKDF2               SHA256 10000 24
 SQLPasswordUserSalt             sql:/GetUserSalt
 

--- a/templates/proftpd.conf.j2
+++ b/templates/proftpd.conf.j2
@@ -77,7 +77,7 @@ SQLNamedQuery                   LookupGalaxyUser SELECT "email,password,'%{env:G
 
 {% elif proftpd_sql_auth_type == "PBKDF2" %}
 
-SQLNamedQuery                   LookupGalaxyUser SELECT "email, (CASE WHEN substring(password from 1 for 6) = 'PBKDF2' THEN substring(password from 38 for 69) ELSE password END) AS password2,'%{env:GALAXY_UID}','%{env:GALAXY_GID}','{{ proftpd_files_dir }}/%U','/bin/bash' FROM galaxy_user WHERE email='%U'"
+SQLNamedQuery                   LookupGalaxyUser SELECT "email, (CASE WHEN substring(password from 1 for 6) = 'PBKDF2' THEN substring(password from 38 for 69) ELSE password END) AS password2,'{{ galaxy_user_uid }}','{{ galaxy_user_gid }}','{{ proftpd_files_dir }}/%U','/bin/bash' FROM galaxy_user WHERE email='%U'"
 SQLNamedQuery                   GetUserSalt SELECT "(CASE WHEN SUBSTRING (password from 1 for 6) = 'PBKDF2' THEN SUBSTRING (password from 21 for 16) END) AS salt FROM galaxy_user WHERE email='%U'"
 SQLDefaultGID                   %{env:GALAXY_GID}
 SQLDefaultUID                   %{env:GALAXY_UID}

--- a/templates/proftpd.conf.j2
+++ b/templates/proftpd.conf.j2
@@ -73,14 +73,14 @@ SQLDefaultHomedir               /var/opt/local/proftpd
 SQLUserInfo                     custom:/LookupGalaxyUser
 {% if proftpd_sql_auth_type == "SHA1" %}
 
-SQLNamedQuery                   LookupGalaxyUser SELECT "email,password,"{{ galaxy_user_uid }}","{{ galaxy_user_gid }}",'{{ proftpd_files_dir }}/%U','/bin/bash' FROM galaxy_user WHERE email='%U'"
+SQLNamedQuery                   LookupGalaxyUser SELECT "email,password,'%{env:GALAXY_UID}','%{env:GALAXY_GID}','{{ proftpd_files_dir }}/%U','/bin/bash' FROM galaxy_user WHERE email='%U'"
 
 {% elif proftpd_sql_auth_type == "PBKDF2" %}
 
-SQLNamedQuery                   LookupGalaxyUser SELECT "email, (CASE WHEN substring(password from 1 for 6) = 'PBKDF2' THEN substring(password from 38 for 69) ELSE password END) AS password2,'{{ galaxy_user_uid }}','{{ galaxy_user_gid }}','{{ proftpd_files_dir }}/%U','/bin/bash' FROM galaxy_user WHERE email='%U'"
+SQLNamedQuery                   LookupGalaxyUser SELECT "email, (CASE WHEN substring(password from 1 for 6) = 'PBKDF2' THEN substring(password from 38 for 69) ELSE password END) AS password2,'%{env:GALAXY_UID}','%{env:GALAXY_GID}','{{ proftpd_files_dir }}/%U','/bin/bash' FROM galaxy_user WHERE email='%U'"
 SQLNamedQuery                   GetUserSalt SELECT "(CASE WHEN SUBSTRING (password from 1 for 6) = 'PBKDF2' THEN SUBSTRING (password from 21 for 16) END) AS salt FROM galaxy_user WHERE email='%U'"
-SQLDefaultGID                   {{ galaxy_user_gid }}
-SQLDefaultUID                   {{ galaxy_user_uid }}
+SQLDefaultGID                   %{env:GALAXY_GID}
+SQLDefaultUID                   %{env:GALAXY_UID}
 SQLPasswordPBKDF2               SHA256 10000 24
 SQLPasswordUserSalt             sql:/GetUserSalt
 

--- a/templates/proftpd.conf.j2
+++ b/templates/proftpd.conf.j2
@@ -77,7 +77,7 @@ SQLNamedQuery                   LookupGalaxyUser SELECT "email,password,"{{ gala
 
 {% elif proftpd_sql_auth_type == "PBKDF2" %}
 
-SQLNamedQuery                   LookupGalaxyUser SELECT "email, (CASE WHEN substring(password from 1 for 6) = 'PBKDF2' THEN substring(password from 38 for 69) ELSE password END) AS password2,"{{ galaxy_user_uid }}","{{ galaxy_user_gid }}",'{{ proftpd_files_dir }}/%U','/bin/bash' FROM galaxy_user WHERE email='%U'"
+SQLNamedQuery                   LookupGalaxyUser SELECT "email, (CASE WHEN substring(password from 1 for 6) = 'PBKDF2' THEN substring(password from 38 for 69) ELSE password END) AS password2,'{{ galaxy_user_uid }}','{{ galaxy_user_gid }}','{{ proftpd_files_dir }}/%U','/bin/bash' FROM galaxy_user WHERE email='%U'"
 SQLNamedQuery                   GetUserSalt SELECT "(CASE WHEN SUBSTRING (password from 1 for 6) = 'PBKDF2' THEN SUBSTRING (password from 21 for 16) END) AS salt FROM galaxy_user WHERE email='%U'"
 SQLDefaultGID                   {{ galaxy_user_gid }}
 SQLDefaultUID                   {{ galaxy_user_uid }}


### PR DESCRIPTION
Issue:

galaxy_user_uid and galaxy_user_gid are hard coded to 512 in https://github.com/galaxyproject/ansible-galaxy-extras/blob/86a127ae3aaaea125c8faa0271471106f2a4f889/templates/proftpd.conf.j2#L80

This does not seem to cause problem for an installation under Ubuntu 14.04. In contrast, this causes an authentification error from proftpd under Ubuntu 16.04.

Fix:
replace `512,512` with `'{{ galaxy_user_uid }}','{{ galaxy_user_gid }}'`

Side notes:

I have doubts that the placeholders %{env:GALAXY_GID} and %{env:GALAXY_UID} are correctly substituted by the corresponding environment variables GALAXY_GID and GALAXY_UID, at least when defined in group_vars/all by:
```
    - export GALAXY_GID="${GALAXY_GID:-{{ galaxy_user_gid }}}"
    - export GALAXY_UID="${GALAXY_UID:-{{ galaxy_user_uid }}}"
```
for instance.

But I am not sure and it does not seem to hurt anyway.