### PR TITLE
fix ie_proxy.yml

### DIFF
--- a/tasks/ie_proxy.yml
+++ b/tasks/ie_proxy.yml
@@ -1,7 +1,7 @@
 - name: Install web related system packages
   apt: pkg={{ item }} state={{ galaxy_extras_apt_package_state }}
   with_items:
-    - nodejs
+    - nodejs-legacy
     - npm
   when: galaxy_extras_install_packages
 

--- a/tasks/ie_proxy.yml
+++ b/tasks/ie_proxy.yml
@@ -12,6 +12,8 @@
 
 - name: "Install proxy dependencies."
   shell: "cd {{ galaxy_server_dir }}/lib/galaxy/web/proxy/js && npm install"
+  become: True
+  become_user: "{{ galaxy_user_name }}"
 
 - name: "Install Juypter container."
   shell: "docker pull {{ galaxy_extras_ie_jupyter_image }}"

--- a/tasks/ie_proxy.yml
+++ b/tasks/ie_proxy.yml
@@ -9,6 +9,7 @@
   file:
     src: /usr/bin/nodejs
     dest: /usr/bin/node
+    state: link
 
 - name: "Install proxy dependencies."
   shell: "cd {{ galaxy_server_dir }}/lib/galaxy/web/proxy/js && npm install"

--- a/tasks/ie_proxy.yml
+++ b/tasks/ie_proxy.yml
@@ -1,14 +1,17 @@
 - name: Install web related system packages
   apt: pkg={{ item }} state={{ galaxy_extras_apt_package_state }}
   with_items:
-    - nodejs-legacy
+    - nodejs
     - npm
   when: galaxy_extras_install_packages
 
+- name: Symlinks node to nodejs
+  file:
+    src: /usr/bin/nodejs
+    dest: /usr/bin/node
+
 - name: "Install proxy dependencies."
   shell: "cd {{ galaxy_server_dir }}/lib/galaxy/web/proxy/js && npm install"
-  become: True
-  become_user: "{{ galaxy_user_name }}"
 
 - name: "Install Juypter container."
   shell: "docker pull {{ galaxy_extras_ie_jupyter_image }}"


### PR DESCRIPTION
- As mentioned in [RTD](https://docs.galaxyproject.org/en/master/admin/interactive_environments.html), : 
```
if you have NodeJS installed under Ubuntu, it often installs to /usr/bin/nodejs, whereas npm expects it to be /usr/bin/node. You will need to create that symlink yourself.
```

- I find that Install proxy dependencies task as `galaxy` user fails. Is there any reason to do so ? My proposed cut allows ansible to install the nodejs proxy in all cases