### PR TITLE
Change signal for stopping galaxy:galaxy_web to stopsignal=QUIT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.idea/
+.vagrant/
+*.retry
+.DS_Store
+*.pyc
+docs/html

--- a/templates/supervisor.conf.j2
+++ b/templates/supervisor.conf.j2
@@ -122,7 +122,7 @@ startsecs       = {{ supervisor_galaxy_startsecs }}
 user            = {{ galaxy_user_name }}
 environment     = PATH={{ galaxy_venv_dir }}:{{ galaxy_venv_dir }}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 numprocs        = 1
-stopsignal      = INT
+stopsignal      = QUIT
 startretries    = {{ supervisor_galaxy_startretries }}
 {% else %}
 # template cache hack https://github.com/galaxyproject/planemo-machine/issues/38


### PR DESCRIPTION
In response to issue discussed in https://github.com/galaxyproject/ansible-galaxy-tools/issues/48,
here we propose to increase the strength of the signal termination sent by supervisor to uwsgi when stopping or restarting the galaxy:web_galaxy service.
This makes more robust the management of this service by a handler discussed in the issue