### PR TITLE
Revert "Remove explicit creation of the nginx upload_store dir"

### DIFF
--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -1,4 +1,10 @@
 ---
+
+- name: Create nginx upload_store dir
+  file:
+    state: directory
+    path: "{{ nginx_upload_store_path }}"
+    owner: "{{ galaxy_user_name }}"
     
 - name: Place configuration files
   template: >


### PR DESCRIPTION
Ping @afgane, seems we do need this to complete the playbook for the
Oslo tutorial, because nginx only uses `mkdir`, not `mkdir -p` to create
the directory.

This reverts commit 7700237125fde70f6be5ef125d6a23f4dea013e1.