### PR TITLE
Change location {{ nginx_galaxy_location }}/_x_accel_redirect {

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -119,7 +119,7 @@ http {
         }
 
         # delegated downloads
-        location {{ nginx_galaxy_location }}/_x_accel_redirect {
+        location /_x_accel_redirect/ {
             internal;
             alias /;
         }


### PR DESCRIPTION
to     location /_x_accel_redirect/ {

as explained in #183, nginx delegated downloads should not be prefixed even with prefixed galaxy frontend. In its current form, downloads fail for prefixed server instances.