### PR TITLE
post-start-actions script placeholder

### DIFF
--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -428,6 +428,19 @@ if [ "x$GALAXY_DEFAULT_ADMIN_USER" != "x" ]
     then
         echo "Creating admin user $GALAXY_DEFAULT_ADMIN_USER with key $GALAXY_DEFAULT_ADMIN_KEY and password $GALAXY_DEFAULT_ADMIN_PASSWORD if not existing"
         python /usr/local/bin/create_galaxy_user.py --user "$GALAXY_DEFAULT_ADMIN_USER" --password "$GALAXY_DEFAULT_ADMIN_PASSWORD" -c "$GALAXY_CONFIG_FILE" --key "$GALAXY_DEFAULT_ADMIN_KEY"
+
+	# If there is a need to execute actions that would require a live galaxy instance, such as adding workflows, setting quotas, adding more users, etc.
+	# then place a file with that logic named post-start-actions.sg on the Galaxy working directory, it should have access to all environment variables 
+	# visible here.
+	# The file needs to be executable (chmod a+x post-start-actions.sh)
+        if [ -x ./post-start-actions.sh ]
+            then
+	       # uses ephemeris, present in docker-galaxy-stable, to wait for the local instance
+	       galaxy-wait -g http://127.0.0.1 -v --timeout 120 > {{ galaxy_log_dir }}/post-start-actions.log &&
+	       ./post-start-actions.sh >> {{ galaxy_log_dir }}/post-start-actions.log &    
+	fi
+
+
 fi
 
 # Enable verbose output

--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -427,8 +427,8 @@ fi
 if [ "x$GALAXY_DEFAULT_ADMIN_USER" != "x" ]
     then
         echo "Creating admin user $GALAXY_DEFAULT_ADMIN_USER with key $GALAXY_DEFAULT_ADMIN_KEY and password $GALAXY_DEFAULT_ADMIN_PASSWORD if not existing"
-        python /usr/local/bin/create_galaxy_user.py --user "$GALAXY_DEFAULT_ADMIN_USER" --password "$GALAXY_DEFAULT_ADMIN_PASSWORD" -c "$GALAXY_CONFIG_FILE"
-
+        python /usr/local/bin/create_galaxy_user.py --user "$GALAXY_DEFAULT_ADMIN_EMAIL" --password "$GALAXY_DEFAULT_ADMIN_PASSWORD" \
+		-c "$GALAXY_CONFIG_FILE" --username "$GALAXY_DEFAULT_ADMIN_USER" --key "$GALAXY_DEFAULT_ADMIN_KEY"
 	# If there is a need to execute actions that would require a live galaxy instance, such as adding workflows, setting quotas, adding more users, etc.
 	# then place a file with that logic named post-start-actions.sg on the Galaxy working directory, it should have access to all environment variables 
 	# visible here.

--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -433,11 +433,11 @@ if [ "x$GALAXY_DEFAULT_ADMIN_USER" != "x" ]
 	# then place a file with that logic named post-start-actions.sg on the Galaxy working directory, it should have access to all environment variables 
 	# visible here.
 	# The file needs to be executable (chmod a+x post-start-actions.sh)
-        if [ -x ./post-start-actions.sh ]
+        if [ -x /export/post-start-actions.sh ]
             then
 	       # uses ephemeris, present in docker-galaxy-stable, to wait for the local instance
 	       galaxy-wait -g http://127.0.0.1 -v --timeout 120 > {{ galaxy_log_dir }}/post-start-actions.log &&
-	       ./post-start-actions.sh >> {{ galaxy_log_dir }}/post-start-actions.log &    
+	       /export/post-start-actions.sh >> {{ galaxy_log_dir }}/post-start-actions.log &    
 	fi
 
 

--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -427,7 +427,7 @@ fi
 if [ "x$GALAXY_DEFAULT_ADMIN_USER" != "x" ]
     then
         echo "Creating admin user $GALAXY_DEFAULT_ADMIN_USER with key $GALAXY_DEFAULT_ADMIN_KEY and password $GALAXY_DEFAULT_ADMIN_PASSWORD if not existing"
-        python /usr/local/bin/create_galaxy_user.py --user "$GALAXY_DEFAULT_ADMIN_USER" --password "$GALAXY_DEFAULT_ADMIN_PASSWORD" -c "$GALAXY_CONFIG_FILE" --key "$GALAXY_DEFAULT_ADMIN_KEY"
+        python /usr/local/bin/create_galaxy_user.py --user "$GALAXY_DEFAULT_ADMIN_USER" --password "$GALAXY_DEFAULT_ADMIN_PASSWORD" -c "$GALAXY_CONFIG_FILE"
 
 	# If there is a need to execute actions that would require a live galaxy instance, such as adding workflows, setting quotas, adding more users, etc.
 	# then place a file with that logic named post-start-actions.sg on the Galaxy working directory, it should have access to all environment variables 

--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -430,7 +430,7 @@ if [ "x$GALAXY_DEFAULT_ADMIN_USER" != "x" ]
         python /usr/local/bin/create_galaxy_user.py --user "$GALAXY_DEFAULT_ADMIN_EMAIL" --password "$GALAXY_DEFAULT_ADMIN_PASSWORD" \
 		-c "$GALAXY_CONFIG_FILE" --username "$GALAXY_DEFAULT_ADMIN_USER" --key "$GALAXY_DEFAULT_ADMIN_KEY"
 	# If there is a need to execute actions that would require a live galaxy instance, such as adding workflows, setting quotas, adding more users, etc.
-	# then place a file with that logic named post-start-actions.sg on the Galaxy working directory, it should have access to all environment variables 
+	# then place a file with that logic named post-start-actions.sh on the /export/ directory, it should have access to all environment variables 
 	# visible here.
 	# The file needs to be executable (chmod a+x post-start-actions.sh)
         if [ -x /export/post-start-actions.sh ]


### PR DESCRIPTION
This PR adds the ability for admins to add an script with logic that should be executed once the galaxy instance is running. `galaxy-wait` is part of ephemeris which is installed in the docker-stable compose images that are relevant to the `startup` script.

I modified slightly the way that the create-user is invoked, to better comply with its usage of admin email and admin user. Previously the email wasn't being used, which risks the admin not being blessed as such, but we can discuss this if needed. 

I have tested the functionality to work with my real use case.

This resolves #184 