### PR TITLE
fix nginx.conf.j2, part 2

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -163,7 +163,7 @@ http {
 
 {% if galaxy_extras_config_nginx_upload == True %}
         # delegated uploads
-        location {{ nginx_galaxy_location }}/_upload {
+        location /_upload {
             upload_store {{ nginx_upload_store_path }};
             upload_store_access user:rw;
             upload_pass_form_field "";
@@ -172,9 +172,9 @@ http {
             upload_set_form_field "${upload_field_name}_name" "$upload_file_name";
             upload_set_form_field "${upload_field_name}_path" "$upload_tmp_path";
             upload_pass_args on;
-            upload_pass {{ nginx_galaxy_location }}/_upload_done;
+            upload_pass /_upload_done;
         }
-        location {{ nginx_galaxy_location }}/_upload_done {
+        location /_upload_done {
             set $dst {{ nginx_galaxy_location }}/api/tools;
             if ($args ~ nginx_redir=([^&]+)) {
                 set $dst $1;


### PR DESCRIPTION
{{ nginx_galaxy_location }} is excessively used in the nginx.conf.j2 section for delegated uploads.

As explained in https://docs.galaxyproject.org/en/latest/admin/special_topics/nginx.html#receiving-files-using-nginx, {{ nginx_galaxy_location }} is only required for the code

```
set $dst {{ nginx_galaxy_location }}/api/tools;
```
other instances of {{ nginx_galaxy_location }} in the section for download settings should be avoided: they cause failing download when prefixing galaxy server with {{ nginx_galaxy_location }}