### PR TITLE
Feature/isatools-lite installation

### DIFF
--- a/tasks/isatools.yml
+++ b/tasks/isatools.yml
@@ -1,0 +1,35 @@
+# Install the unofficial isatools lite for the Galaxy ISA -tab and -json datatypes
+# Assumes pip 9
+- name: Install packages 
+  apt: pkg={{ item }} state={{ galaxy_extras_apt_package_state }}
+  with_items:
+   - git
+  when: isatools_lite_install
+
+- name: Install networkx
+  pip:
+    name: networkx
+    virtualenv: "{{ galaxy_venv_dir }}"
+    virtualenv_command: "{{ pip_virtualenv_command | default( 'virtualenv' ) }}"
+  when: isatools_lite_install
+  become: True
+  become_user: "{{ galaxy_user_name }}"
+
+- name: Install isatools-lite unofficial
+  pip:
+    name: git+https://github.com/ilveroluca/isa-rwval@feature/fewer_deps#egg=isatools
+    virtualenv: "{{ galaxy_venv_dir }}"
+    virtualenv_command: "{{ pip_virtualenv_command | default( 'virtualenv' ) }}"
+    extra_args: "--no-deps"
+  when: isatools_lite_install
+  become: True
+  become_user: "{{ galaxy_user_name }}"
+
+- name: Remove packages
+  apt: pkg={{ item }} state=absent
+  with_items:
+   - git
+  when: isatools_lite_install
+
+
+

--- a/tasks/isatools.yml
+++ b/tasks/isatools.yml
@@ -17,7 +17,7 @@
 
 - name: Install isatools-lite unofficial
   pip:
-    name: git+https://github.com/ilveroluca/isa-rwval@feature/fewer_deps#egg=isatools
+    name: git+https://github.com/isa-tools/isa-rwval@develop#egg=isatools
     virtualenv: "{{ galaxy_venv_dir }}"
     virtualenv_command: "{{ pip_virtualenv_command | default( 'virtualenv' ) }}"
     extra_args: "--no-deps"

--- a/tasks/isatools.yml
+++ b/tasks/isatools.yml
@@ -6,21 +6,11 @@
    - git
   when: isatools_lite_install
 
-- name: Install networkx
-  pip:
-    name: networkx
-    virtualenv: "{{ galaxy_venv_dir }}"
-    virtualenv_command: "{{ pip_virtualenv_command | default( 'virtualenv' ) }}"
-  when: isatools_lite_install
-  become: True
-  become_user: "{{ galaxy_user_name }}"
-
 - name: Install isatools-lite unofficial
   pip:
     name: git+https://github.com/isa-tools/isa-rwval@develop#egg=isatools
     virtualenv: "{{ galaxy_venv_dir }}"
     virtualenv_command: "{{ pip_virtualenv_command | default( 'virtualenv' ) }}"
-    extra_args: "--no-deps"
   when: isatools_lite_install
   become: True
   become_user: "{{ galaxy_user_name }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,6 +43,11 @@
   tags:
    - k8s
 
+- include: isatools.yml
+  when: isatools_lite_install
+  tags:
+   - isatools 
+
 - include: condor.yml
   when: galaxy_extras_config_condor
   tags:

--- a/tasks/uwsgi.yml
+++ b/tasks/uwsgi.yml
@@ -1,6 +1,7 @@
 - name: "Install uwsgi for galaxy"
   pip: 
     name: uwsgi
+    version: 2.0.15
     virtualenv: "{{ galaxy_venv_dir }}"
     virtualenv_command: "{{ pip_virtualenv_command | default( 'virtualenv' ) }}"
     extra_args: "--extra-index-url https://wheels.galaxyproject.org/"


### PR DESCRIPTION
This PR adds an isatools-lite optional install managed by ansible to support the functionality of the isa-tab and isa-json composite datatypes recently contributed by PhenoMeNal. This will be executed in the compose galaxy-init container provided that a build argument `--build-arg ISATOOLS_LITE_INSTALL=True` is given on docker build.

It also pins uwsgi to version 2.0.15 as a new version 2.0.16 came for which there is no wheel, producing failures when building containers.