### PR TITLE
Adds thunder-lock to avoid race conditions between multiple uwsgi threads

### DIFF
--- a/templates/supervisor.conf.j2
+++ b/templates/supervisor.conf.j2
@@ -112,9 +112,9 @@ priority        = 200
 [program:galaxy_web]
 {% if galaxy_uwsgi|bool %}
 {% if galaxy_uwsgi_static_conf|bool %}
-command         = {{ galaxy_venv_dir }}/bin/uwsgi --virtualenv {{ galaxy_venv_dir }} --yaml {{ galaxy_config_file }} --logdate --master --processes {{ galaxy_web_processes }} --threads {{ uwsgi_threads }} --logto {{ uwsgi_log }} --socket 127.0.0.1:{{ uwsgi_port }} --pythonpath lib --stats 127.0.0.1:9191 -b 16384
+command         = {{ galaxy_venv_dir }}/bin/uwsgi --virtualenv {{ galaxy_venv_dir }} --yaml {{ galaxy_config_file }} --logdate --thunder-lock --master --processes {{ galaxy_web_processes }} --threads {{ uwsgi_threads }} --logto {{ uwsgi_log }} --socket 127.0.0.1:{{ uwsgi_port }} --pythonpath lib --stats 127.0.0.1:9191 -b 16384
 {% else %}
-command         = {{ galaxy_venv_dir }}/bin/uwsgi --virtualenv {{ galaxy_venv_dir }} --yaml {{ galaxy_config_file }} --logdate --master --processes %(ENV_UWSGI_PROCESSES)s --threads %(ENV_UWSGI_THREADS)s --logto {{ uwsgi_log }} --socket 127.0.0.1:{{ uwsgi_port }} --pythonpath lib --stats 127.0.0.1:9191 -b 16384
+command         = {{ galaxy_venv_dir }}/bin/uwsgi --virtualenv {{ galaxy_venv_dir }} --yaml {{ galaxy_config_file }} --logdate --thunder-lock --master --processes %(ENV_UWSGI_PROCESSES)s --threads %(ENV_UWSGI_THREADS)s --logto {{ uwsgi_log }} --socket 127.0.0.1:{{ uwsgi_port }} --pythonpath lib --stats 127.0.0.1:9191 -b 16384
 {% endif %}
 directory       = {{ galaxy_server_dir }}
 umask           = 022


### PR DESCRIPTION
This PR addresses the issue described in https://github.com/bgruening/docker-galaxy-stable/issues/423. I would love to hear if you have been avoiding the `--thunder-lock` option for some reason, as in my local and OpenStack tests this looks good and seems to avoid the race condition previously described.

@natefoo any thoughts about usage of `--thuder-lock`?

Thanks!