### PR TITLE
Trust insecure npm

### DIFF
--- a/tasks/ie_proxy.yml
+++ b/tasks/ie_proxy.yml
@@ -25,7 +25,7 @@
   apt: pkg=nodejs state=latest update_cache=true
 
 - name: "Install proxy dependencies."
-  shell: "cd {{ galaxy_server_dir }}/lib/galaxy/web/proxy/js && npm install"
+  shell: "cd {{ galaxy_server_dir }}/lib/galaxy/web/proxy/js && npm config set strict-ssl false && npm install"
   become: True
   become_user: "{{ galaxy_user_name }}"
 


### PR DESCRIPTION
This allows allows building images again after issues described in #198, produced due to some issue in npm repo's certificate. I reckon this should be temporal and we might want to revert this later.