### PR TITLE
introduce a {{ galaxy_config_style }} variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -105,6 +105,8 @@ galaxy_reports_config_file: "{{ galaxy_config_dir }}/reports_wsgi.ini"
 galaxy_toolshed_config_file: "{{ galaxy_config_dir }}/tool_shed.ini"
 galaxy_tool_data_table_config_file: "{{ galaxy_config_dir }}/tool_data_table_conf.xml"
 
+# the other option for galaxy_config_style is "ini-paste"
+galaxy_config_style: "yaml" 
 galaxy_config_file: "{{ galaxy_config_dir }}/galaxy.ini"
 galaxy_reports_port: "9001"
 galaxy_reports_log: "{{ galaxy_log_dir }}/reports.log"

--- a/templates/supervisor.conf.j2
+++ b/templates/supervisor.conf.j2
@@ -112,9 +112,9 @@ priority        = 200
 [program:galaxy_web]
 {% if galaxy_uwsgi|bool %}
 {% if galaxy_uwsgi_static_conf|bool %}
-command         = {{ galaxy_venv_dir }}/bin/uwsgi --virtualenv {{ galaxy_venv_dir }} --yaml {{ galaxy_config_file }} --logdate --thunder-lock --master --processes {{ galaxy_web_processes }} --threads {{ uwsgi_threads }} --logto {{ uwsgi_log }} --socket 127.0.0.1:{{ uwsgi_port }} --pythonpath lib --stats 127.0.0.1:9191 -b 16384
+command         = {{ galaxy_venv_dir }}/bin/uwsgi --virtualenv {{ galaxy_venv_dir }} --{{ galaxy_config_style }} {{ galaxy_config_file }} --logdate --thunder-lock --master --processes {{ galaxy_web_processes }} --threads {{ uwsgi_threads }} --logto {{ uwsgi_log }} --socket 127.0.0.1:{{ uwsgi_port }} --pythonpath lib --stats 127.0.0.1:9191 -b 16384
 {% else %}
-command         = {{ galaxy_venv_dir }}/bin/uwsgi --virtualenv {{ galaxy_venv_dir }} --yaml {{ galaxy_config_file }} --logdate --thunder-lock --master --processes %(ENV_UWSGI_PROCESSES)s --threads %(ENV_UWSGI_THREADS)s --logto {{ uwsgi_log }} --socket 127.0.0.1:{{ uwsgi_port }} --pythonpath lib --stats 127.0.0.1:9191 -b 16384
+command         = {{ galaxy_venv_dir }}/bin/uwsgi --virtualenv {{ galaxy_venv_dir }} --{{ galaxy_config_style }} {{ galaxy_config_file }} --logdate --thunder-lock --master --processes %(ENV_UWSGI_PROCESSES)s --threads %(ENV_UWSGI_THREADS)s --logto {{ uwsgi_log }} --socket 127.0.0.1:{{ uwsgi_port }} --pythonpath lib --stats 127.0.0.1:9191 -b 16384
 {% endif %}
 directory       = {{ galaxy_server_dir }}
 umask           = 022


### PR DESCRIPTION
Fixes uwsgi start up by supervisor with old style galaxy.ini config file, ensuring compatibility with older galaxy release.

This fix was successfully tested on GalaxyKickStart
https://travis-ci.org/ARTbio/GalaxyKickStart/jobs/378385895