### PR TITLE
Multi-suite testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,12 @@ language: python
 python: "2.7"
 
 env:
-  - TOX_ENV=py27
+  global:
+    - TOX_ENV=py27
+  matrix:
+    - SUITE=docker-galaxy
+    - SUITE=planemo-machine
+    - SUITE=syntax
 
 services:
   - docker
@@ -27,29 +32,7 @@ install:
   # Add ansible.cfg to pick up roles path.
   - printf '[defaults]\nroles_path = ../' > ansible.cfg
 
-  # download the Galaxy Docker image and build it to test the playrole
-  - mkdir $HOME/galaxy-docker
-  - wget -q -O - https://github.com/bgruening/docker-galaxy-stable/archive/master.tar.gz | tar xzf - --strip-components=1 -C $HOME/galaxy-docker
-  # remove the submodule role
-  - rm $HOME/galaxy-docker/galaxy/roles/galaxyprojectdotorg.galaxyextras/* -rf
-  - wget https://raw.githubusercontent.com/galaxyproject/galaxy-flavor-testing/master/Makefile -O $HOME/galaxy-docker/Makefile
-  # install BioBlend
-  - make install -f $HOME/galaxy-docker/Makefile
-
 script:
-  # Check the role/playbook's syntax.
-  - ansible-playbook -i "localhost," tests/syntax.yml --syntax-check
-  # Copy the ansible-playbook from this repo into the Docker roles directory and build the image.
-  - cp -r ./* $HOME/galaxy-docker/galaxy/roles/galaxyprojectdotorg.galaxyextras/
-  - ls -l $HOME/galaxy-docker/galaxy/roles/galaxyprojectdotorg.galaxyextras/
-  - cd $HOME/galaxy-docker/ && docker build -t galaxy-docker/test ./galaxy/
-  # run various tests against the container
-  - make docker_run
-  - sleep 30
-  - make test_api
-  - make test_ftp
-  - make test_bioblend
-  #- make test_docker_in_docker
-  # Test the conditional loading of dependencies.
-  - cd $HOME/galaxy-docker/galaxy/roles/galaxyprojectdotorg.galaxyextras/
-  - bash tests/conditional_deps/test_script.sh
+  - if [ "$SUITE" == "syntax" ]; then ansible-playbook -i "localhost," tests/syntax.yml --syntax-check; fi
+  - if [ "$SUITE" == "docker-galaxy" ]; then bash ci_test_docker_galaxy.sh; fi
+  - if [ "$SUITE" == "planemo-machine" ]; then bash ci_test_planemo_machine.sh; fi

--- a/ci_test_docker_galaxy.sh
+++ b/ci_test_docker_galaxy.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+mkdir $HOME/galaxy-docker
+wget -q -O - https://github.com/bgruening/docker-galaxy-stable/archive/master.tar.gz | tar xzf - --strip-components=1 -C $HOME/galaxy-docker
+
+# remove the submodule role
+rm $HOME/galaxy-docker/galaxy/roles/galaxyprojectdotorg.galaxyextras/* -rf
+wget https://raw.githubusercontent.com/galaxyproject/galaxy-flavor-testing/master/Makefile -O $HOME/galaxy-docker/Makefile
+
+# install BioBlend
+make install -f $HOME/galaxy-docker/Makefile
+
+# Check the role/playbook's syntax.
+ansible-playbook -i "localhost," tests/syntax.yml --syntax-check
+# Copy the ansible-playbook from this repo into the Docker roles directory and build the image.
+cp -r ./* $HOME/galaxy-docker/galaxy/roles/galaxyprojectdotorg.galaxyextras/
+ls -l $HOME/galaxy-docker/galaxy/roles/galaxyprojectdotorg.galaxyextras/
+cd $HOME/galaxy-docker/ && docker build -t galaxy-docker/test ./galaxy/
+# run various tests against the container
+make docker_run
+sleep 30
+make test_api
+make test_ftp
+make test_bioblend
+
+# Test the conditional loading of dependencies.
+cd $HOME/galaxy-docker/galaxy/roles/galaxyprojectdotorg.galaxyextras/
+bash tests/conditional_deps/test_script.sh

--- a/ci_test_planemo_machine.sh
+++ b/ci_test_planemo_machine.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+PLANEMO_MACHINE_DIR="${HOME}/planemo-machine-test"
+git clone https://github.com/galaxyproject/planemo-machine $PLANEMO_MACHINE_DIR
+
+( cd ${PLANEMO_MACHINE_DIR} && git submodule update --init )
+
+# remove the submodule role
+rm -rf ${PLANEMO_MACHINE_DIR}/roles/galaxyprojectdotorg.galaxy-extras/*
+
+# Copy the ansible-playbook from this repo into the Docker roles directory and build the image.
+cp -r ./* "${PLANEMO_MACHINE_DIR}/roles/galaxyprojectdotorg.galaxy-extras/"
+
+cd "${PLANEMO_MACHINE_DIR}"
+bash ci_test.sh


### PR DESCRIPTION
Re-organize test files and scripts to allow multiple test suites. Test updates against planemo machine and docker-galaxy-stable. Provides a clearer path toward integrating other external tests as well hopefully.

Final fix to fix https://github.com/galaxyproject/ansible-galaxy-extras/issues/40.