### PR TITLE
Drop 'packed' path component for all nginx locations, it's just static now.

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -73,7 +73,7 @@ http {
             expires 24h;
         }
         location {{ nginx_reports_location }}/static/scripts {
-            alias {{ galaxy_server_dir }}/static/scripts/packed;
+            alias {{ galaxy_server_dir }}/static/scripts;
             gzip on;
             gzip_types text/plain text/javascript application/x-javascript;
             expires 24h;
@@ -112,7 +112,7 @@ http {
             expires 24h;
         }
         location {{ nginx_galaxy_location }}/static/scripts {
-            alias {{ galaxy_server_dir }}/static/scripts/packed;
+            alias {{ galaxy_server_dir }}/static/scripts;
             gzip on;
             gzip_types text/plain text/javascript application/x-javascript;
             expires 24h;


### PR DESCRIPTION
Missed one in #205 