### PR TITLE
Propose change to keep-alive timeout nginx.

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -16,7 +16,7 @@ http {
 
     sendfile        on;
 
-    keepalive_timeout  65;
+    keepalive_timeout  600;
     types_hash_max_size 2048;
 
     gzip  on;


### PR DESCRIPTION
When managing dependencies in the admin panel, conda runs in the background. This might take longer than 65 seconds, at which point a gateway timeout follows.
Lets increase the keep-alive timeout. I set 600 for now, but another default should be more sane.