### PR TITLE
Fix missing favicon.ico

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -117,6 +117,9 @@ http {
             gzip_types text/plain text/javascript application/x-javascript;
             expires 24h;
         }
+        location /favicon.ico {
+            alias {{ galaxy_server_dir }}/static/favicon.ico;
+        }
 
         # delegated downloads
         location /_x_accel_redirect/ {


### PR DESCRIPTION
The same is being done in the usegalaxy.org template:
https://github.com/galaxyproject/usegalaxy-playbook/blob/8825178e89a49d611e92a5a01606dbaf8324c6d8/env/main/templates/nginx/usegalaxy.j2#L101