### PR TITLE
[18.09] fix cvmfs install

### DIFF
--- a/tasks/cvmfs_client.yml
+++ b/tasks/cvmfs_client.yml
@@ -4,7 +4,9 @@
 
 # Install autofs
 - name: Install autofs system package
-  apt: pkg=['autofs', 'uuid-runtime'] state={{ galaxy_extras_apt_package_state }}
+  apt:
+    name: ['autofs', 'uuid-runtime']
+    state: "{{ galaxy_extras_apt_package_state }}"
   when: galaxy_extras_install_packages
 
 - name: Install CernVM apt key

--- a/tasks/cvmfs_client.yml
+++ b/tasks/cvmfs_client.yml
@@ -4,11 +4,12 @@
 
 # Install autofs
 - name: Install autofs system package
-  apt: pkg={{ item }} state={{ galaxy_extras_apt_package_state }}
-  with_items:
-    - autofs
-    - uuid-runtime
+  apt: pkg=['autofs', 'uuid-runtime'] state={{ galaxy_extras_apt_package_state }}
   when: galaxy_extras_install_packages
+
+- name: Install CernVM apt key
+  apt_key:
+    url: https://cvmrepo.web.cern.ch/cvmrepo/apt/cernvm.gpg
 
 # Install & setup CermVM-FS
 - name: Configure CernVM apt repository
@@ -17,16 +18,11 @@
     mode: 422
     repo: deb https://cvmrepo.web.cern.ch/cvmrepo/apt/ stable main
 
-- name: Install CernVM apt key
-  apt_key:
-    url: https://cvmrepo.web.cern.ch/cvmrepo/apt/cernvm.gpg
-
 - name: Install CernVM-FS client (apt)
   apt:
     name: ['cvmfs', 'cvmfs-config']
     state: "{{ galaxy_extras_apt_package_state }}"
     update_cache: yes
-    allow_unauthenticated: yes
 
 - name: Install CernVM-FS keys
   copy:

--- a/tasks/ie_proxy.yml
+++ b/tasks/ie_proxy.yml
@@ -5,14 +5,14 @@
 
 - name: Ensure apt-transport-https is installed.
   apt: name=apt-transport-https state={{ galaxy_extras_apt_package_state }}
-  when: distro_supported is success
+  when: distro_supported is succeeded
 
 - name: Add Nodesource apt key.
   apt_key:
     url: https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280
     id: "68576280"
     state: "{{ galaxy_extras_apt_package_state }}"
-  when: distro_supported is success
+  when: distro_supported is succeeded
 
 - name: Add NodeSource repositories for Node.js.
   apt_repository:
@@ -21,7 +21,7 @@
   with_items:
     - "deb https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_release }} main"
     - "deb-src https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_release }} main"
-  when: distro_supported is success
+  when: distro_supported is succeeded
 
 - name: Install nodejs (npm is included)
   apt: pkg=nodejs state=latest update_cache=true

--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -240,7 +240,7 @@ fi
 # Waits until postgres is ready
 function wait_for_postgres {
     echo "Checking if database is up and running"
-    until /usr/local/bin/check_database.py 2>&1 >/dev/null; do sleep 1; echo "Waiting for database"; done
+    until /usr/local/bin/check_database.py; do sleep 1; echo "Waiting for database"; done 2>/dev/null
     echo "Database connected"
 }
 


### PR DESCRIPTION
I'm trying to fix errors in the galaxy docker compose images (a PR should come soon).
I found this problem with apt install of cvmfs, I *think* the key needs to be installed before adding the apt repo