### PR TITLE
[18.09] small fixes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 # https://github.com/bgruening/docker-galaxy-stable.
 
 galaxy_extras_config_nginx: true
-galaxy_extras_config_nginx_upload: true
+galaxy_extras_config_nginx_upload: false
 galaxy_extras_config_postgres: true
 galaxy_extras_config_proftpd: true
 galaxy_extras_config_slurm: true

--- a/tasks/supervisor.yml
+++ b/tasks/supervisor.yml
@@ -7,6 +7,12 @@
     - supervisor
   when: galaxy_extras_install_packages
 
+- name: Install cron
+  apt: pkg={{ item }} state={{ galaxy_extras_apt_package_state }}
+  with_items:
+    - cron
+  when: supervisor_manage_cron|bool and galaxy_extras_install_packages
+
 - name: Create Galaxy configuration file
   template: src=supervisor.conf.j2 dest={{ supervisor_conf_path }}
 

--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -398,6 +398,7 @@ then
     --extra-vars galaxy_extras_config_ssl=True \
     --extra-vars galaxy_extras_config_ssl_method=letsencrypt \
     --extra-vars galaxy_extras_galaxy_domain="GALAXY_CONFIG_GALAXY_INFRASTRUCTURE_URL" \
+    --extra-vars galaxy_extras_config_nginx_upload=False \
     --tags https
 fi
 if [ "$USE_HTTPS" != "False" ]
@@ -411,6 +412,7 @@ then
         --extra-vars galaxy_extras_config_ssl_method=own \
         --extra-vars src_nginx_ssl_certificate_key=/export/server.key \
         --extra-vars src_nginx_ssl_certificate=/export/server.crt \
+        --extra-vars galaxy_extras_config_nginx_upload=False \
         --tags https
     else
         echo "Setting up self-signed SSL keys"
@@ -418,6 +420,7 @@ then
         --extra-vars gather_facts=False \
         --extra-vars galaxy_extras_config_ssl=True \
         --extra-vars galaxy_extras_config_ssl_method=self-signed \
+        --extra-vars galaxy_extras_config_nginx_upload=False \
         --tags https
     fi
 fi


### PR DESCRIPTION
2 fixes for errors found in https://github.com/bgruening/docker-galaxy-stable/pull/464
- make sure cron is installed when it is managed by supervisor
- make sure the nginx upload module is not enabled when asking for https support. It is [disabled in http mode](https://github.com/bgruening/docker-galaxy-stable/blob/edbef97c5fa8f4d9d0f8e54db72b85bccba6d51e/compose/galaxy-web/Dockerfile#L61), but it was not specified here and it's [enabled by default](https://github.com/galaxyproject/ansible-galaxy-extras/blob/18.09/defaults/main.yml#L5).