### PR TITLE
[18.09] cvmfs version

### DIFF
--- a/tasks/cvmfs_client.yml
+++ b/tasks/cvmfs_client.yml
@@ -18,7 +18,7 @@
   apt_repository:
     filename: "cernvm.list"
     mode: 422
-    repo: deb https://cvmrepo.web.cern.ch/cvmrepo/apt/ stable main
+    repo: deb https://cvmrepo.web.cern.ch/cvmrepo/apt/ {{ ansible_distribution_release }}-prod main
 
 - name: Install CernVM-FS client (apt)
   apt:


### PR DESCRIPTION
Another little fix, this time for cvmfs install: the stable apt repo contains packages for ubuntu 12.04, so it doesn't run on ubuntu 18.04 because libcrypto.so is not found.
Switching to `{{ ansible_distribution_release }}-prod` to get the good repo