### PR TITLE
Auto-update galaxy at startup

### DIFF
--- a/templates/export_user_files.py.j2
+++ b/templates/export_user_files.py.j2
@@ -118,7 +118,7 @@ if __name__ == "__main__":
     if os.environ.get('GALAXY_AUTO_UPDATE_CONDA', '0') != 0:
         src_conda = '/tool_deps/_conda/'
         dest_conda = '/export/tool_deps/_conda/'
-        if not os.path.realpath(src_conda) == os.path.realpath(dest_conda):
+        if os.path.exists(dest_conda) and os.path.realpath(src_conda) != os.path.realpath(dest_conda):
             for subdir in ['bin', 'compiler_compat', 'conda-meta', 'etc', 'include', 'lib', 'share', 'ssl', 'x86_64-conda_cos6-linux-gnu']:
                 if os.path.exists(os.path.join(dest_conda, subdir)):
                     shutil.rmtree(os.path.join(dest_conda, subdir))

--- a/templates/export_user_files.py.j2
+++ b/templates/export_user_files.py.j2
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import glob
 import sys
 import os
 import shutil
@@ -89,6 +90,16 @@ if __name__ == "__main__":
         if os.path.exists(export_config):
             subprocess.call('ln -s -f %s %s' % (export_config, image_config), shell=True)
 
+    # Update Conda version if needed
+    if os.environ.get('GALAXY_AUTO_UPDATE_CONDA', '0') != 0:
+        src_conda = '/tool_deps/_conda/'
+        dest_conda = '/export/tool_deps/_conda/'
+        if not os.path.realpath(src_conda) == os.path.realpath(dest_conda):
+            for subdir in ['bin', 'compiler_compat', 'conda-meta', 'envs', 'etc', 'include', 'lib', 'share', 'ssl', 'x86_64-conda_cos6-linux-gnu']:
+                if os.path.exists(os.path.join(dest_conda, subdir)):
+                    shutil.rmtree(os.path.join(dest_conda, subdir))
+                shutil.copytree(os.path.join(src_conda, subdir), os.path.join(dest_conda, subdir))
+
     change_path( os.path.join(galaxy_root_dir, 'tools.yaml') )
     change_path( os.path.join(galaxy_root_dir, 'integrated_tool_panel.xml') )
     change_path( os.path.join(galaxy_root_dir, 'display_applications') )
@@ -96,7 +107,7 @@ if __name__ == "__main__":
     change_path( os.path.join(galaxy_root_dir, 'tool-data') )
     change_path( os.path.join(galaxy_root_dir, 'database') )
     change_path( '/shed_tools/' )
-    
+
     if os.path.exists('/export/reports_htpasswd'):
         shutil.copy('/export/reports_htpasswd', '/etc/nginx/htpasswd')
 

--- a/templates/export_user_files.py.j2
+++ b/templates/export_user_files.py.j2
@@ -122,7 +122,7 @@ if __name__ == "__main__":
             for subdir in ['bin', 'compiler_compat', 'conda-meta', 'envs', 'etc', 'include', 'lib', 'share', 'ssl', 'x86_64-conda_cos6-linux-gnu']:
                 if os.path.exists(os.path.join(dest_conda, subdir)):
                     shutil.rmtree(os.path.join(dest_conda, subdir))
-                shutil.copytree(os.path.join(src_conda, subdir), os.path.join(dest_conda, subdir))
+                subprocess.call('cp -p --preserve -R %s %s' % (os.path.join(src_conda, subdir), os.path.join(dest_conda, subdir)), shell=True)
 
     change_path( os.path.join(galaxy_root_dir, 'tools.yaml') )
     change_path( os.path.join(galaxy_root_dir, 'integrated_tool_panel.xml') )
@@ -154,4 +154,3 @@ if __name__ == "__main__":
         subprocess.call('chown -R postgres:postgres /export/postgresql/', shell=True)
         subprocess.call('chmod -R 0755 /export/', shell=True)
         subprocess.call('chmod -R 0700 %s' % PG_DATA_DIR_HOST, shell=True)
-

--- a/templates/export_user_files.py.j2
+++ b/templates/export_user_files.py.j2
@@ -37,6 +37,17 @@ def change_path( src ):
                         os.unlink( stripped_src )
                     os.symlink( dest, src.rstrip('/') )
 
+
+def copy_samples(src, dest):
+    if not os.path.realpath(src) == os.path.realpath(dest):
+        for filename in os.listdir(src):
+            if filename.endswith('ml.sample') or filename.endswith('ml.sample_advanced') or filename.endswith('ml.sample_basic'):
+                distrib_file = os.path.join(src, filename)
+                export_file = os.path.join(dest, filename)
+                shutil.copy(distrib_file, export_file)
+                os.chown(export_file, int(os.environ['GALAXY_UID']), int(os.environ['GALAXY_GID']))
+
+
 def _makedir(path):
     if not os.path.exists( path ):
         os.makedirs( path )
@@ -63,6 +74,24 @@ if __name__ == "__main__":
 
     shutil.copy('/galaxy-central/requirements.txt','/export/galaxy-central/requirements.txt')
 
+    _makedir('/export/galaxy-central/')
+    _makedir('/export/ftp/')
+
+    change_path( os.path.join(galaxy_root_dir, 'config') )
+
+    # Copy all sample config files to config dir
+    # TODO find a way to update plugins/ without breaking user customizations
+    config_src = os.path.join(galaxy_root_dir, 'config')
+    config_dest = os.path.join('/export/', galaxy_root_dir, 'config')
+    copy_samples(config_src, config_dest)
+
+    # Copy all sample files to tool-data dir
+    # TODO find a way to update shared/ without breaking user customizations
+    tool_data_src = os.path.join(galaxy_root_dir, 'tool-data')
+    tool_data_dest = os.path.join('/export/', galaxy_root_dir, 'tool-data')
+    copy_samples(tool_data_src, tool_data_dest)
+
+    # TODO find a way to update /export/galaxy-central/display_applications/ without breaking user customizations
 
     # Copy all files starting with "welcome"
     # This enables a flexible start page design.
@@ -72,11 +101,6 @@ if __name__ == "__main__":
             image_file = os.path.join('/etc/galaxy/web/', filename)
             shutil.copy(export_file, image_file)
             os.chown( image_file, int(os.environ['GALAXY_UID']), int(os.environ['GALAXY_GID']) )
-
-    _makedir('/export/galaxy-central/')
-    _makedir('/export/ftp/')
-
-    change_path( os.path.join(galaxy_root_dir, 'config') )
 
     # copy image defaults to config/<file>.docker_sample to base derivatives on,
     # and if there is a realized version of these files in the export directory

--- a/templates/export_user_files.py.j2
+++ b/templates/export_user_files.py.j2
@@ -119,7 +119,7 @@ if __name__ == "__main__":
         src_conda = '/tool_deps/_conda/'
         dest_conda = '/export/tool_deps/_conda/'
         if not os.path.realpath(src_conda) == os.path.realpath(dest_conda):
-            for subdir in ['bin', 'compiler_compat', 'conda-meta', 'envs', 'etc', 'include', 'lib', 'share', 'ssl', 'x86_64-conda_cos6-linux-gnu']:
+            for subdir in ['bin', 'compiler_compat', 'conda-meta', 'etc', 'include', 'lib', 'share', 'ssl', 'x86_64-conda_cos6-linux-gnu']:
                 if os.path.exists(os.path.join(dest_conda, subdir)):
                     shutil.rmtree(os.path.join(dest_conda, subdir))
                 subprocess.call('cp -p --preserve -R %s %s' % (os.path.join(src_conda, subdir), os.path.join(dest_conda, subdir)), shell=True)

--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -463,7 +463,7 @@ if [ "x$GALAXY_AUTO_UPDATE_TOOLS" != "x" ]
         IFS=','
         for TOOL_YML in `echo "$GALAXY_AUTO_UPDATE_TOOLS"`
         do
-            echo "Installing tools from $TOOLS_YML"
+            echo "Installing tools from $TOOL_YML"
             install-tools "$TOOL_YML" -v
             /tool_deps/_conda/bin/conda clean --tarballs --yes
         done
@@ -481,4 +481,3 @@ if [ `echo ${GALAXY_LOGGING:-'no'} | tr [:upper:] [:lower:]` = "full" ]
     else
         tail -f {{ galaxy_log_dir }}/*.log
 fi
-

--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -106,6 +106,7 @@ umount /var/lib/docker
 # If /export/ is mounted, export_user_files file moving all data to /export/
 # symlinks will point from the original location to the new path under /export/
 # If /export/ is not given, nothing will happen in that step
+echo "Checking /export..."
 python /usr/local/bin/export_user_files.py $PG_DATA_DIR_DEFAULT
 {% endif %}
 
@@ -240,7 +241,7 @@ fi
 # Waits until postgres is ready
 function wait_for_postgres {
     echo "Checking if database is up and running"
-    until /usr/local/bin/check_database.py; do sleep 1; echo "Waiting for database"; done
+    until /usr/local/bin/check_database.py 2>&1 >/dev/null; do sleep 1; echo "Waiting for database"; done
     echo "Database connected"
 }
 

--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -473,7 +473,7 @@ if [ "x$GALAXY_AUTO_UPDATE_TOOLS" != "x" ]
         for TOOL_YML in `echo "$GALAXY_AUTO_UPDATE_TOOLS"`
         do
             echo "Installing tools from $TOOL_YML"
-            install-tools "$TOOL_YML" -v
+            shed-tools install -g "http://127.0.0.1" -a "$GALAXY_DEFAULT_ADMIN_KEY" -t "$TOOL_YML"
             /tool_deps/_conda/bin/conda clean --tarballs --yes
         done
         IFS=$OLDIFS

--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -164,6 +164,15 @@ if [ "x$BARE" != "x" ]
         export GALAXY_CONFIG_TOOL_CONFIG_FILE=config/shed_tool_conf.xml,$GALAXY_ROOT/test/functional/tools/upload_tool_conf.xml
 fi
 
+# If auto installing conda envs, make sure bcftools is installed for __set_metadata__ tool
+if [ "x$GALAXY_CONFIG_CONDA_AUTO_INSTALL" != "x" ]
+    then
+        if [ ! -d "/tool_deps/_conda/envs/__bcftools@1.5" ]; then
+            /tool_deps/_conda/bin/conda create -y --override-channels --channel iuc --channel conda-forge --channel bioconda --channel defaults --name __bcftools@1.5 bcftools=1.5
+            /tool_deps/_conda/bin/conda clean --tarballs --yes
+        fi
+fi
+
 {% if galaxy_extras_config_postgres|bool %}
 if [[ $NONUSE != *"postgres"* ]]
 then

--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -280,6 +280,14 @@ function start_supervisor {
     fi
     {% endif %}
     wait_for_postgres
+
+    # Make sure the database is automatically updated
+    if [ "x$GALAXY_AUTO_UPDATE_DB" != "x" ]
+    then
+        echo "Updating Galaxy database"
+        sh manage_db.sh -c /etc/galaxy/galaxy.yml upgrade
+    fi
+
     {% if supervisor_manage_cron|bool %}
     if [[ $NONUSE != *"cron"* ]]
     then

--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -98,9 +98,31 @@ if [ "x$DISABLE_REPORTS_AUTH" != "x" ]
         cp {{ nginx_conf_directory }}/reports_auth.conf.source {{ nginx_conf_directory }}/reports_auth.conf
 fi
 
+# Try to guess if we are running under --privileged mode
+{% if host_docker_legacy|bool %}
+if mount | grep "/proc/kcore"; then
+    PRIVILEGED=false
+else
+    PRIVILEGED=true
+fi
+{% else %}
+# Taken from http://stackoverflow.com/questions/32144575/how-to-know-if-a-docker-container-is-running-in-privileged-mode
+ip link add dummy0 type dummy >/dev/null
+if [[ $? -eq 0 ]]; then
+    PRIVILEGED=true
+    # clean the dummy0 link
+    ip link delete dummy0 >/dev/null
+else
+    PRIVILEGED=false
+fi
+{% endif %}
+
 cd {{ galaxy_server_dir }}
 . {{ galaxy_venv_dir }}/bin/activate
-umount /var/lib/docker
+
+if $PRIVILEGED; then
+    umount /var/lib/docker
+fi
 
 {% if startup_export_user_files is defined and startup_export_user_files|bool %}
 # If /export/ is mounted, export_user_files file moving all data to /export/
@@ -334,25 +356,6 @@ then
 fi
 {% endif %}
 
-# Try to guess if we are running under --privileged mode
-{% if host_docker_legacy|bool %}
-if mount | grep "/proc/kcore"; then
-    PRIVILEGED=false
-else
-    PRIVILEGED=true
-fi
-{% else %}
-# Taken from http://stackoverflow.com/questions/32144575/how-to-know-if-a-docker-container-is-running-in-privileged-mode
-ip link add dummy0 type dummy >/dev/null
-if [[ $? -eq 0 ]]; then
-    PRIVILEGED=true
-    # clean the dummy0 link
-    ip link delete dummy0 >/dev/null
-else
-    PRIVILEGED=false
-fi
-{% endif %}
-# Try to guess if we are running under --privileged mode
 if $PRIVILEGED; then
     echo "Enable Galaxy Interactive Environments."
     export GALAXY_CONFIG_INTERACTIVE_ENVIRONMENT_PLUGINS_DIRECTORY="config/plugins/interactive_environments"

--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -455,6 +455,21 @@ if [ "x$GALAXY_DEFAULT_ADMIN_USER" != "x" ]
 	fi
 fi
 
+# Reinstall tools if the user want to
+if [ "x$GALAXY_AUTO_UPDATE_TOOLS" != "x" ]
+    then
+        galaxy-wait -g http://127.0.0.1 -v --timeout 120 > /home/galaxy/logs/post-start-actions.log &&
+        OLDIFS=$IFS
+        IFS=','
+        for TOOL_YML in `echo "$GALAXY_AUTO_UPDATE_TOOLS"`
+        do
+            echo "Installing tools from $TOOLS_YML"
+            install-tools "$TOOL_YML" -v
+            /tool_deps/_conda/bin/conda clean --tarballs --yes
+        done
+        IFS=$OLDIFS
+fi
+
 # migrate custom IEs or Visualisations (Galaxy plugins)
 # this is needed for by the new client build system
 python3 ${GALAXY_ROOT}/scripts/plugin_staging.py


### PR DESCRIPTION
Hi,
Here's a patch to ease my life: I have several small Galaxy containers running, and updating them is always a mess...

So I've made this patch to do this at startup:
- update most of the config sample files
- update the database (only if the new `GALAXY_AUTO_UPDATE_DB` is set)
- update all tools from the flavor yml list(s) (only if the path to yml file(s) is provided with the new `GALAXY_AUTO_UPDATE_TOOLS` var)
- update the conda install installed in /export/tool_deps (only if the new `GALAXY_AUTO_UPDATE_CONDA` is set)

Enabling all of this in a production instance could be quite risky :D. But well, for my instances it would save me a lot of headaches. And as it's disabled by default, I guess it shouldn't be a problem for other people.
Any comments welcome of course!