### PR TITLE
Use galaxy user to install bcftools env

### DIFF
--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -168,8 +168,8 @@ fi
 if [ "x$GALAXY_CONFIG_CONDA_AUTO_INSTALL" != "x" ]
     then
         if [ ! -d "/tool_deps/_conda/envs/__bcftools@1.5" ]; then
-            /tool_deps/_conda/bin/conda create -y --override-channels --channel iuc --channel conda-forge --channel bioconda --channel defaults --name __bcftools@1.5 bcftools=1.5
-            /tool_deps/_conda/bin/conda clean --tarballs --yes
+            su $GALAXY_USER -c "/tool_deps/_conda/bin/conda create -y --override-channels --channel iuc --channel conda-forge --channel bioconda --channel defaults --name __bcftools@1.5 bcftools=1.5"
+            su $GALAXY_USER -c "/tool_deps/_conda/bin/conda clean --tarballs --yes"
         fi
 fi
 


### PR DESCRIPTION
A fix for a little bug found while testing the 18.09.1 docker image: bcftools env is installed as root, which can cause some permission problems when installing other envs later