### PR TITLE
adding Ubuntu 18.04 compatibility

### DIFF
--- a/tasks/galaxy_extra_dependencies.yml
+++ b/tasks/galaxy_extra_dependencies.yml
@@ -4,7 +4,7 @@
     name: "{{item}}"
     virtualenv: "{{ galaxy_venv_dir }}"
     virtualenv_command: "{{ pip_virtualenv_command | default( 'virtualenv' ) }}"
-    extra_args: --index-url https://wheels.galaxyproject.org/simple
+    extra_args: "--index-url https://wheels.galaxyproject.org/simple  --extra-index-url https://pypi.python.org/simple"
   become: True
   become_user: "{{ galaxy_user_name }}"
   with_items:

--- a/tasks/galaxy_root.yml
+++ b/tasks/galaxy_root.yml
@@ -13,7 +13,6 @@
     name: "watchdog"
     virtualenv: "{{ galaxy_venv_dir }}"
     virtualenv_command: "{{ pip_virtualenv_command | default( 'virtualenv' ) }}"
-    extra_args: --index-url https://wheels.galaxyproject.org/simple
   become: True
   become_user: "{{ galaxy_user_name }}"
 

--- a/tasks/pbs.yml
+++ b/tasks/pbs.yml
@@ -9,7 +9,7 @@
 - name: Fetch DRMAA wheel for Galaxy
   pip:
     name: "drmaa"
-    extra_args: "--index-url https://wheels.galaxyproject.org/simple/"
+    extra_args: "--index-url https://wheels.galaxyproject.org/simple/ --extra-index-url https://pypi.python.org/simple"
     virtualenv: "{{ galaxy_venv_dir }}"
   environment:
     PYTHOPATH: null

--- a/tasks/slurm.yml
+++ b/tasks/slurm.yml
@@ -78,7 +78,7 @@
 - name: Fetch DRMAA wheel for Galaxy
   pip:
     name: "drmaa"
-    extra_args: "--index-url https://wheels.galaxyproject.org/simple/"
+    extra_args: "--index-url https://wheels.galaxyproject.org/simple/ --extra-index-url https://pypi.python.org/simple"
     virtualenv: "{{ galaxy_venv_dir }}"
   environment:
     PYTHOPATH: null

--- a/tasks/slurm.yml
+++ b/tasks/slurm.yml
@@ -18,7 +18,22 @@
     - slurm-llnl
     - slurm-drmaa-dev
     - python-psutil
-  when: galaxy_extras_install_packages
+  when: galaxy_extras_install_packages and ansible_distribution_version < "18.04"
+
+- name: Add custom Galaxy PPA (used for Slurm DRMAA package in Ubuntu 18.04)
+  apt_repository: 
+    repo: ppa:natefoo/slurm-drmaa
+    state: present
+    update_cache: yes
+  when: galaxy_extras_install_packages and ansible_distribution_version == "18.04"
+
+- name: Install SLURM system packages for Ubuntu 18.04
+  apt: pkg={{ item }} state={{ galaxy_extras_apt_package_state }}
+  with_items:
+    - slurm-wlm
+    - slurm-drmaa-dev
+    - python-psutil
+  when: galaxy_extras_install_packages and ansible_distribution_version == "18.04"
 
 - name: Install SLURM system packages
   apt: pkg={{ item }} state={{ galaxy_extras_apt_package_state }}

--- a/templates/configure_slurm.py.j2
+++ b/templates/configure_slurm.py.j2
@@ -77,7 +77,7 @@ SlurmctldDebug=3
 SlurmdDebug=3
 #SlurmdLogFile=
 NodeName=$hostname CPUs=$cpus RealMemory=$memory State=UNKNOWN
-PartitionName=$partition_name Nodes=$hostname Default=YES MaxTime=INFINITE State=UP Shared=YES {% if ansible_distribution=='Ubuntu' and ansible_distribution_version | version_compare('15.04', '>=') %}DefMemPerCPU=$mem_per_cpu
+PartitionName=$partition_name Nodes=$hostname Default=YES MaxTime=INFINITE State=UP Shared=YES {% if ansible_distribution=='Ubuntu' and ansible_distribution_version is version_compare('15.04', '>=') %}DefMemPerCPU=$mem_per_cpu
 {% endif %}
 '''
 

--- a/templates/configure_slurm.py.j2
+++ b/templates/configure_slurm.py.j2
@@ -80,9 +80,14 @@ NodeName=$hostname CPUs=$cpus RealMemory=$memory State=UNKNOWN
 PartitionName=$partition_name Nodes=$hostname Default=YES MaxTime=INFINITE State=UP Shared=YES {% if ansible_distribution=='Ubuntu' and ansible_distribution_version | version_compare('15.04', '>=') %}DefMemPerCPU=$mem_per_cpu
 {% endif %}
 '''
-slurm_status = subprocess.check_output(['slurmd', '-C'])
-cpus = slurm_status.split("CPUs=")[1].split(" Boards")[0]
-memory = slurm_status.split("RealMemory=")[1].split(" TmpDisk")[0]
+
+slurm_status = {}
+for kv in subprocess.check_output(['slurmd', '-C']).split():
+  split_kv = kv.split('=')
+  slurm_status[split_kv[0]] = split_kv[1]
+
+cpus = slurm_status["CPUs"]
+memory = slurm_status["RealMemory"]
 mem_per_cpu = int(memory) / int(cpus)
 
 def main():

--- a/templates/startup.sh.j2
+++ b/templates/startup.sh.j2
@@ -139,7 +139,7 @@ if [[ "x$LOAD_GALAXY_CONDITIONAL_DEPENDENCIES" != "x" ]]
         echo "Installing optional dependencies in galaxy virtual environment..."
         : ${GALAXY_WHEELS_INDEX_URL:="https://wheels.galaxyproject.org/simple"}
         GALAXY_CONDITIONAL_DEPENDENCIES=$(PYTHONPATH=lib python -c "import galaxy.dependencies; print '\n'.join(galaxy.dependencies.optional('$GALAXY_CONFIG_FILE'))")
-        [ -z "$GALAXY_CONDITIONAL_DEPENDENCIES" ] || echo "$GALAXY_CONDITIONAL_DEPENDENCIES" | pip install -q -r /dev/stdin --index-url "${GALAXY_WHEELS_INDEX_URL}"
+        [ -z "$GALAXY_CONDITIONAL_DEPENDENCIES" ] || echo "$GALAXY_CONDITIONAL_DEPENDENCIES" | pip install -q -r /dev/stdin --index-url "${GALAXY_WHEELS_INDEX_URL}" --extra-index-url https://pypi.python.org/simple
 fi
 
 if [[ "x$LOAD_GALAXY_CONDITIONAL_DEPENDENCIES" != "x"  ]] && [[ "x$LOAD_PYTHON_DEV_DEPENDENCIES" != "x" ]]
@@ -147,7 +147,7 @@ if [[ "x$LOAD_GALAXY_CONDITIONAL_DEPENDENCIES" != "x"  ]] && [[ "x$LOAD_PYTHON_D
         echo "Installing development requirements in galaxy virtual environment..."
         : ${GALAXY_WHEELS_INDEX_URL:="https://wheels.galaxyproject.org/simple"}
         dev_requirements='./lib/galaxy/dependencies/dev-requirements.txt'
-        [ -f $dev_requirements ] && pip install -q -r $dev_requirements --index-url "${GALAXY_WHEELS_INDEX_URL}"
+        [ -f $dev_requirements ] && pip install -q -r $dev_requirements --index-url "${GALAXY_WHEELS_INDEX_URL}" --extra-index-url https://pypi.python.org/simple
 fi
 
 # Enable Test Tool Shed


### PR DESCRIPTION
This PR addresses a few issues with using this component of the GalaxyKickstart stack:
1. using `ppa:natefoo/slurm-drmaa` to get slurm components
2. slurm-wlm in lieu of slurm-llnl when using Ubuntu 18.04
3. fix in ` templates/configure_slurm.py.j2` to deal with some cruft left in the 'split' mechanism of status parsing

this has been tested on Ubuntu 18.04; i was able to install some tools from the shed and run [Galaxy 101](https://galaxyproject.org/tutorials/g101/) to completion. When using it as part of GalaxyKickstart, I successfully installed to Ubuntu 16.04 and 18.04, though it required some modifications to galaxy-os which i plan to issue a PR to should this approach be deemed acceptable.

critiques welcome!