### PR TITLE
Improve repo testing (introducing a galaxykickstart job)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 ---
 language: python
-python: "2.7"
+python: 2.7
+dist: xenial
+sudo: required
 
 env:
   global:
     - TOX_ENV=py27
   matrix:
+    - SUITE=galaxykickstart
     - SUITE=docker-galaxy
     - SUITE=planemo-machine
     - SUITE=syntax
@@ -27,7 +30,7 @@ before_install:
 
 install:
   # Install Ansible.
-  - pip install ansible
+  - pip install ansible==2.7.4
 
   # Add ansible.cfg to pick up roles path.
   - printf '[defaults]\nroles_path = ../' > ansible.cfg
@@ -35,4 +38,5 @@ install:
 script:
   - if [ "$SUITE" == "syntax" ]; then ansible-playbook -i "localhost," tests/syntax.yml --syntax-check; fi
   - if [ "$SUITE" == "docker-galaxy" ]; then bash ci_test_docker_galaxy.sh; fi
+  - if [ "$SUITE" == "galaxykickstart" ]; then bash ci_test_galaxykickstart.sh; fi
   - if [ "$SUITE" == "planemo-machine" ]; then bash ci_test_planemo_machine.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
 
 install:
   # Install Ansible.
-  - pip install ansible==2.7.4
+  - pip install ansible
 
   # Add ansible.cfg to pick up roles path.
   - printf '[defaults]\nroles_path = ../' > ansible.cfg

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ before_install:
 install:
   # Install Ansible.
   - pip install ansible
+  - ansible --version
 
   # Add ansible.cfg to pick up roles path.
   - printf '[defaults]\nroles_path = ../' > ansible.cfg

--- a/ci_test_docker_galaxy.sh
+++ b/ci_test_docker_galaxy.sh
@@ -2,8 +2,11 @@
 
 set -e
 
-mkdir $HOME/galaxy-docker
-wget -q -O - https://github.com/bgruening/docker-galaxy-stable/archive/master.tar.gz | tar xzf - --strip-components=1 -C $HOME/galaxy-docker
+# this failed because galaxy-postgresql is not recursively imported
+# mkdir $HOME/galaxy-docker
+# wget -q -O - https://github.com/bgruening/docker-galaxy-stable/archive/master.tar.gz | tar xzf - --strip-components=1 -C $HOME/galaxy-docker
+
+git clone --recursive https://github.com/bgruening/docker-galaxy-stable $HOME/galaxy-docker
 
 # remove the submodule role
 rm $HOME/galaxy-docker/galaxy/roles/galaxyprojectdotorg.galaxyextras/* -rf

--- a/ci_test_galaxykickstart.sh
+++ b/ci_test_galaxykickstart.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -e
+export GALAXY_USER="admin@galaxy.org"
+export GALAXY_USER_EMAIL="admin@galaxy.org"
+export GALAXY_USER_PASSWD="admin"
+export GALAXY_HOME=/home/galaxy
+export GALAXY_TRAVIS_USER=galaxy
+export GALAXY_UID=1450
+export GALAXY_GID=1450
+export BIOBLEND_GALAXY_API_KEY=admin
+export BIOBLEND_GALAXY_URL=http://127.0.0.1:80
+export BIOBLEND_TEST_JOB_TIMEOUT=240
+
+sudo /etc/init.d/postgresql stop
+sudo apt-get -y --purge remove postgresql libpq-dev libpq5 postgresql-client-common postgresql-common
+sudo rm -rf /var/lib/postgresql
+
+git clone http://github.com/artbio/galaxykickstart $HOME/galaxykickstart
+ansible-galaxy install -r $HOME/galaxykickstart/upstream_requirements_roles.yml \
+  -p $HOME/galaxykickstart/roles -f
+# remove ansible-galaxy-extras for testing
+rm -rf $HOME/galaxykickstart/roles/galaxyprojectdotorg.galaxy-extras/*
+cp -r ./* $HOME/galaxykickstart/roles/galaxyprojectdotorg.galaxy-extras/
+
+# install and update galaxykickstart with ansible
+ansible-playbook -i $HOME/galaxykickstart/inventory_files/galaxy-kickstart $HOME/galaxykickstart/galaxy.yml
+ansible-playbook -i $HOME/galaxykickstart/inventory_files/galaxy-kickstart $HOME/galaxykickstart/galaxy.yml
+
+sudo supervisorctl status
+curl http://localhost:80/api/version| grep version_major
+curl --fail $BIOBLEND_GALAXY_URL/api/version
+date > $HOME/date.txt && curl --fail -T $HOME/date.txt ftp://127.0.0.1:21 --user $GALAXY_USER:$GALAXY_USER_PASSWD
+
+# install bioblend testing, GKS way.
+pip --version
+sudo rm -f /etc/boto.cfg
+sudo su $GALAXY_TRAVIS_USER -c 'pip install --ignore-installed --user https://github.com/galaxyproject/bioblend/archive/master.zip pytest'
+
+
+sudo -E su $GALAXY_TRAVIS_USER -c "export PATH=$GALAXY_HOME/.local/bin/:$PATH &&
+cd $GALAXY_HOME &&
+bioblend-galaxy-tests -v -k 'not download_dataset and \
+              not download_history and \
+              not export_and_download and \
+              not test_show_nonexistent_dataset and \
+              not test_invocation and \
+              not test_update_dataset_tags and \
+              not test_upload_file_contents_with_tags and \
+              not test_create_local_user and \
+              not test_show_workflow_versions' $GALAXY_HOME/.local/lib/python2.7/site-packages/bioblend/_tests/TestGalaxy*.py"
+cd $TRAVIS_BUILD_DIR

--- a/tasks/galaxy_root.yml
+++ b/tasks/galaxy_root.yml
@@ -11,9 +11,9 @@
 - name: "Install watchdog for galaxy"
   pip:
     name: "watchdog"
+    version: 0.9.0
     virtualenv: "{{ galaxy_venv_dir }}"
     virtualenv_command: "{{ pip_virtualenv_command | default( 'virtualenv' ) }}"
-    extra_args: --index-url https://wheels.galaxyproject.org/simple
   become: True
   become_user: "{{ galaxy_user_name }}"
 

--- a/tasks/slurm.yml
+++ b/tasks/slurm.yml
@@ -63,7 +63,7 @@
 - name: Fetch DRMAA wheel for Galaxy
   pip:
     name: "drmaa"
-    extra_args: "--index-url https://wheels.galaxyproject.org/simple/"
+    version: 0.7.9
     virtualenv: "{{ galaxy_venv_dir }}"
   environment:
     PYTHOPATH: null

--- a/templates/configure_slurm.py.j2
+++ b/templates/configure_slurm.py.j2
@@ -77,7 +77,7 @@ SlurmctldDebug=3
 SlurmdDebug=3
 #SlurmdLogFile=
 NodeName=$hostname CPUs=$cpus RealMemory=$memory State=UNKNOWN
-PartitionName=$partition_name Nodes=$hostname Default=YES MaxTime=INFINITE State=UP Shared=YES {% if ansible_distribution=='Ubuntu' and ansible_distribution_version | version_compare('15.04', '>=') %}DefMemPerCPU=$mem_per_cpu
+PartitionName=$partition_name Nodes=$hostname Default=YES MaxTime=INFINITE State=UP Shared=YES {% if ansible_distribution=='Ubuntu' and ansible_distribution_version is version('15.04', '>=') %}DefMemPerCPU=$mem_per_cpu
 {% endif %}
 '''
 slurm_status = subprocess.check_output(['slurmd', '-C'])


### PR DESCRIPTION
Here is an attempt to improve the automatic tests for this repo.
- Since the `ci_test_docker_galaxy.sh` is failing since several months, I introduced a similar procedure which instead of being based on galaxy-docker-stable is based on [galaxykickstart](https://github.com/ARTbio/GalaxyKickStart.git).

- Before that, I had also worked a bit on the `ci_test_docker_galaxy.sh` issues and I kept some fixes in this PR (in particular the postgresql is now installed, see #237 ). There are still some fixes to be found but I did not had time to do it. To whom it may concern, I identified a strange issue with the apt-get install of condor package.

- The PR is doing a regular pip install of watchdog and slurm, as a turn around of #235. I saw that @bgruening is currently working on that and I will be happy to pick any commits that address the issue better than my quick and dirty patch.