### PR TITLE
Fix nginx conf for icon display in releases >=19.09

### DIFF
--- a/ci_test_galaxykickstart.sh
+++ b/ci_test_galaxykickstart.sh
@@ -40,7 +40,7 @@ sudo su $GALAXY_TRAVIS_USER -c 'pip install --ignore-installed --user https://gi
 sudo -E su $GALAXY_TRAVIS_USER -c "export PATH=$GALAXY_HOME/.local/bin/:$PATH &&
 cd $GALAXY_HOME &&
 bioblend-galaxy-tests -v -k 'not test_collections_in_history_index and \
-              not test_create_list_in_history \
+              not test_create_list_in_history and \
               not download_dataset and \
               not download_history and \
               not export_and_download and \

--- a/ci_test_galaxykickstart.sh
+++ b/ci_test_galaxykickstart.sh
@@ -34,7 +34,7 @@ date > $HOME/date.txt && curl --fail -T $HOME/date.txt ftp://127.0.0.1:21 --user
 # install bioblend testing, GKS way.
 pip --version
 sudo rm -f /etc/boto.cfg
-sudo su $GALAXY_TRAVIS_USER -c 'pip install --ignore-installed --user https://github.com/galaxyproject/bioblend/archive/master.zip pytest'
+sudo su $GALAXY_TRAVIS_USER -c 'pip install --ignore-installed --user bioblend==0.14.0 pytest'
 
 
 sudo -E su $GALAXY_TRAVIS_USER -c "export PATH=$GALAXY_HOME/.local/bin/:$PATH &&

--- a/ci_test_galaxykickstart.sh
+++ b/ci_test_galaxykickstart.sh
@@ -16,6 +16,7 @@ sudo apt-get -y --purge remove postgresql libpq-dev libpq5 postgresql-client-com
 sudo rm -rf /var/lib/postgresql
 
 git clone http://github.com/artbio/galaxykickstart $HOME/galaxykickstart
+pip install ansible==2.7.4
 ansible-galaxy install -r $HOME/galaxykickstart/upstream_requirements_roles.yml \
   -p $HOME/galaxykickstart/roles -f
 # remove ansible-galaxy-extras for testing
@@ -23,7 +24,6 @@ rm -rf $HOME/galaxykickstart/roles/galaxyprojectdotorg.galaxy-extras/*
 cp -r ./* $HOME/galaxykickstart/roles/galaxyprojectdotorg.galaxy-extras/
 
 # install and update galaxykickstart with ansible
-ansible-playbook -i $HOME/galaxykickstart/inventory_files/galaxy-kickstart $HOME/galaxykickstart/galaxy.yml
 ansible-playbook -i $HOME/galaxykickstart/inventory_files/galaxy-kickstart $HOME/galaxykickstart/galaxy.yml
 
 sudo supervisorctl status
@@ -39,15 +39,9 @@ sudo su $GALAXY_TRAVIS_USER -c 'pip install --ignore-installed --user https://gi
 
 sudo -E su $GALAXY_TRAVIS_USER -c "export PATH=$GALAXY_HOME/.local/bin/:$PATH &&
 cd $GALAXY_HOME &&
-bioblend-galaxy-tests -v -k 'not test_collections_in_history_index and \
-              not test_create_list_in_history and \
-              not download_dataset and \
-              not download_history and \
-              not export_and_download and \
-              not test_show_nonexistent_dataset and \
-              not test_invocation and \
-              not test_update_dataset_tags and \
-              not test_upload_file_contents_with_tags and \
-              not test_create_local_user and \
-              not test_show_workflow_versions' $GALAXY_HOME/.local/lib/python2.7/site-packages/bioblend/_tests/TestGalaxy*.py"
+bioblend-galaxy-tests -v -k \
+         'not test_invocation and \
+          not test_update_dataset_tags and \
+          not test_upload_file_contents_with_tags and \
+          not test_show_workflow_versions' $GALAXY_HOME/.local/lib/python2.7/site-packages/bioblend/_tests/TestGalaxy*.py"
 cd $TRAVIS_BUILD_DIR

--- a/ci_test_galaxykickstart.sh
+++ b/ci_test_galaxykickstart.sh
@@ -34,7 +34,7 @@ date > $HOME/date.txt && curl --fail -T $HOME/date.txt ftp://127.0.0.1:21 --user
 # install bioblend testing, GKS way.
 pip --version
 sudo rm -f /etc/boto.cfg
-sudo su $GALAXY_TRAVIS_USER -c 'pip install --ignore-installed --user bioblend==0.14.0 pytest'
+sudo su $GALAXY_TRAVIS_USER -c 'pip install --ignore-installed --user bioblend==0.13.0 pytest'
 
 
 sudo -E su $GALAXY_TRAVIS_USER -c "export PATH=$GALAXY_HOME/.local/bin/:$PATH &&

--- a/ci_test_galaxykickstart.sh
+++ b/ci_test_galaxykickstart.sh
@@ -39,7 +39,9 @@ sudo su $GALAXY_TRAVIS_USER -c 'pip install --ignore-installed --user https://gi
 
 sudo -E su $GALAXY_TRAVIS_USER -c "export PATH=$GALAXY_HOME/.local/bin/:$PATH &&
 cd $GALAXY_HOME &&
-bioblend-galaxy-tests -v -k 'not download_dataset and \
+bioblend-galaxy-tests -v -k 'not test_collections_in_history_index and \
+              not test_create_list_in_history \
+              not download_dataset and \
               not download_history and \
               not export_and_download and \
               not test_show_nonexistent_dataset and \

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -72,6 +72,12 @@ http {
             gzip_types text/plain text/xml text/javascript text/css application/x-javascript;
             expires 24h;
         }
+        location {{ nginx_reports_location }}/static/style/blue {
+            alias {{ galaxy_server_dir }}/client/galaxy/images;
+            gzip on;
+            gzip_types text/plain text/xml text/javascript text/css application/x-javascript;
+            expires 24h;
+        }
         location {{ nginx_reports_location }}/static/scripts {
             alias {{ galaxy_server_dir }}/static/scripts;
             gzip on;
@@ -107,6 +113,12 @@ http {
         }
         location {{ nginx_galaxy_location }}/static/style {
             alias {{ galaxy_server_dir }}/static/style/blue;
+            gzip on;
+            gzip_types text/plain text/xml text/javascript text/css application/x-javascript;
+            expires 24h;
+        }
+        location {{ nginx_galaxy_location }}/static/style/blue {
+            alias {{ galaxy_server_dir }}/client/galaxy/images;
             gzip on;
             gzip_types text/plain text/xml text/javascript text/css application/x-javascript;
             expires 24h;


### PR DESCRIPTION
- I found these patches are enough to display correctly small icons in the `manage tool` panel.
Not sure it is the more elegant patch to adapt to the new path of these png files, but it does not hurt previous releases either

- The PR also fixes the ci_test_galaxykickstart.sh by using ansible 2.7.4 instead of ansible 2.9.2. A side info from this fix is that the ansible-galaxy-tools role should be fixed to accommodate ansible 2.9.2 - if desired (probably a problem of access rights differently managed by the two ansible versions).