### PR TITLE
Fix supervisor and proftpd tasks, and repo testing by gks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
         - ansible-playbook -i "localhost," tests/syntax.yml --syntax-check
 
     - name: "Galaxy Kickstart"
-      python: "3.6"
+      python: "3.7"
       env: SUITE=galaxykickstart
       script:
         - bash ci_test_galaxykickstart.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
         - ansible-playbook -i "localhost," tests/syntax.yml --syntax-check
 
     - name: "Galaxy Kickstart"
-      python: "3.7"
+      python: "3.6"
       env: SUITE=galaxykickstart
       script:
         - bash ci_test_galaxykickstart.sh

--- a/ci_test_galaxykickstart.sh
+++ b/ci_test_galaxykickstart.sh
@@ -16,7 +16,7 @@ sudo apt-get -y --purge remove postgresql libpq-dev libpq5 postgresql-client-com
 sudo rm -rf /var/lib/postgresql
 
 git clone http://github.com/artbio/galaxykickstart -b newgks $HOME/galaxykickstart
-ansible-galaxy install -r $HOME/galaxykickstart/upstream_requirements_roles.yml \
+ansible-galaxy install -r $HOME/galaxykickstart/requirements_roles.yml \
   -p $HOME/galaxykickstart/roles -f
 # remove ansible-galaxy-extras for testing
 rm -rf $HOME/galaxykickstart/roles/galaxyprojectdotorg.galaxy-extras/*

--- a/ci_test_galaxykickstart.sh
+++ b/ci_test_galaxykickstart.sh
@@ -22,9 +22,10 @@ ansible-galaxy install -r $HOME/galaxykickstart/upstream_requirements_roles.yml 
 rm -rf $HOME/galaxykickstart/roles/galaxyprojectdotorg.galaxy-extras/*
 cp -r ./* $HOME/galaxykickstart/roles/galaxyprojectdotorg.galaxy-extras/
 
-# install and update galaxykickstart with ansible
+# install galaxy and user&tools
 ansible-playbook -i $HOME/galaxykickstart/inventory_files/galaxy-kickstart $HOME/galaxykickstart/galaxy.yml
-ansible-playbook -i $HOME/galaxykickstart/inventory_files/galaxy-kickstart $HOME/galaxykickstart/galaxy.yml
+sleep 30
+ansible-playbook -i $HOME/galaxykickstart/inventory_files/galaxy-kickstart $HOME/galaxykickstart/galaxy_tool_install.yml
 
 sudo supervisorctl status
 curl http://localhost:80/api/version| grep version_major

--- a/ci_test_galaxykickstart.sh
+++ b/ci_test_galaxykickstart.sh
@@ -15,7 +15,7 @@ sudo /etc/init.d/postgresql stop
 sudo apt-get -y --purge remove postgresql libpq-dev libpq5 postgresql-client-common postgresql-common
 sudo rm -rf /var/lib/postgresql
 
-git clone http://github.com/artbio/galaxykickstart $HOME/galaxykickstart
+git clone http://github.com/artbio/galaxykickstart -b newgks $HOME/galaxykickstart
 ansible-galaxy install -r $HOME/galaxykickstart/upstream_requirements_roles.yml \
   -p $HOME/galaxykickstart/roles -f
 # remove ansible-galaxy-extras for testing

--- a/ci_test_galaxykickstart.sh
+++ b/ci_test_galaxykickstart.sh
@@ -24,7 +24,7 @@ cp -r ./* $HOME/galaxykickstart/roles/galaxyprojectdotorg.galaxy-extras/
 
 # install galaxy and user&tools
 ansible-playbook -i $HOME/galaxykickstart/inventory_files/galaxy-kickstart $HOME/galaxykickstart/galaxy.yml
-sleep 45
+sleep 15
 ansible-playbook -i $HOME/galaxykickstart/inventory_files/galaxy-kickstart $HOME/galaxykickstart/galaxy_tool_install.yml
 
 sudo supervisorctl status
@@ -51,5 +51,6 @@ bioblend-galaxy-tests -v -k 'not download_dataset and \
               not test_update_dataset_tags and \
               not test_upload_file_contents_with_tags and \
               not test_create_local_user and \
+              not test_update_dataset_datatype and \
               not test_show_workflow_versions' /home/travis/virtualenv/python3.7/lib/python3.7/site-packages/bioblend/_tests/TestGalaxy*.py"
 cd $TRAVIS_BUILD_DIR

--- a/ci_test_galaxykickstart.sh
+++ b/ci_test_galaxykickstart.sh
@@ -24,12 +24,18 @@ cp -r ./* $HOME/galaxykickstart/roles/galaxyprojectdotorg.galaxy-extras/
 
 # install galaxy and user&tools
 ansible-playbook -i $HOME/galaxykickstart/inventory_files/galaxy-kickstart $HOME/galaxykickstart/galaxy.yml
-sleep 30
+sleep 45
 ansible-playbook -i $HOME/galaxykickstart/inventory_files/galaxy-kickstart $HOME/galaxykickstart/galaxy_tool_install.yml
 
 sudo supervisorctl status
 curl http://localhost:80/api/version| grep version_major
 curl --fail $BIOBLEND_GALAXY_URL/api/version
+
+sleep 15
+
+proftpd --version
+sudo -E su $GALAXY_TRAVIS_USER -c "ftp localhost"
+
 date > $HOME/date.txt && curl --fail -T $HOME/date.txt ftp://127.0.0.1:21 --user $GALAXY_USER:$GALAXY_USER_PASSWD
 
 # install bioblend testing, GKS way.

--- a/ci_test_galaxykickstart.sh
+++ b/ci_test_galaxykickstart.sh
@@ -7,7 +7,7 @@ export GALAXY_HOME=/home/galaxy
 export GALAXY_TRAVIS_USER=galaxy
 export GALAXY_UID=1450
 export GALAXY_GID=1450
-export BIOBLEND_GALAXY_API_KEY=admin
+export BIOBLEND_GALAXY_API_KEY="artbio2020"
 export BIOBLEND_GALAXY_URL=http://127.0.0.1:80
 export BIOBLEND_TEST_JOB_TIMEOUT=240
 

--- a/ci_test_galaxykickstart.sh
+++ b/ci_test_galaxykickstart.sh
@@ -2,7 +2,7 @@
 set -e
 export GALAXY_USER="admin@galaxy.org"
 export GALAXY_USER_EMAIL="admin@galaxy.org"
-export GALAXY_USER_PASSWD="admin"
+export GALAXY_USER_PASSWD="artbio2020"
 export GALAXY_HOME=/home/galaxy
 export GALAXY_TRAVIS_USER=galaxy
 export GALAXY_UID=1450
@@ -31,12 +31,9 @@ sudo supervisorctl status
 curl http://localhost:80/api/version| grep version_major
 curl --fail $BIOBLEND_GALAXY_URL/api/version
 
-sleep 15
-
+echo "test proftpd"
 proftpd --version
-sudo -E su $GALAXY_TRAVIS_USER -c "ftp localhost"
-
-date > $HOME/date.txt && curl --fail -T $HOME/date.txt ftp://127.0.0.1:21 --user $GALAXY_USER:$GALAXY_USER_PASSWD
+date > $HOME/date.txt && curl --fail -T $HOME/date.txt ftp://127.0.0.1:21 --user $GALAXY_USER_EMAIL:$GALAXY_USER_PASSWD
 
 # install bioblend testing, GKS way.
 pip --version

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -107,7 +107,7 @@ http {
             expires 24h;
         }
         location {{ nginx_galaxy_location }}/static/style {
-            alias {{ galaxy_server_dir }}/static/style/blue;
+            alias {{ galaxy_server_dir }}/static/style;
             gzip on;
             gzip_types text/plain text/xml text/javascript text/css application/x-javascript;
             expires 24h;

--- a/templates/proftpd.conf.j2
+++ b/templates/proftpd.conf.j2
@@ -51,7 +51,7 @@ AuthPAM                         off
 
 {% macro SQL_Auth() -%}
 
-# Set up mod_sql_password - Galaxy passwords are stored as hex-encoded SHA1
+# Set up mod_sql_password - Galaxy passwords used to be stored as hex-encoded SHA1 and are now stored as base64 encoded SHA256 (PBKDF2 function)
 SQLPasswordEngine               on
 {% if proftpd_sql_auth_type == "SHA1" %}
 SQLPasswordEncoding             hex
@@ -77,11 +77,11 @@ SQLNamedQuery                   LookupGalaxyUser SELECT "email,password,'%{env:G
 
 {% elif proftpd_sql_auth_type == "PBKDF2" %}
 
-SQLNamedQuery                   LookupGalaxyUser SELECT "email, (CASE WHEN substring(password from 1 for 6) = 'PBKDF2' THEN substring(password from 38 for 69) ELSE password END) AS password2,'{{ galaxy_user_uid }}','{{ galaxy_user_gid }}','{{ proftpd_files_dir }}/%U','/bin/bash' FROM galaxy_user WHERE email='%U'"
-SQLNamedQuery                   GetUserSalt SELECT "(CASE WHEN SUBSTRING (password from 1 for 6) = 'PBKDF2' THEN SUBSTRING (password from 21 for 16) END) AS salt FROM galaxy_user WHERE email='%U'"
+SQLNamedQuery                   LookupGalaxyUser SELECT "email, (CASE WHEN substring(password from 1 for 6) = 'PBKDF2' THEN split_part(password, '$', 5) ELSE password END) AS password2,'{{ galaxy_user_uid }}','{{ galaxy_user_gid }}','{{ proftpd_files_dir }}/%U','/bin/bash' FROM galaxy_user WHERE email='%U'"
+SQLNamedQuery                   GetUserSalt SELECT "(CASE WHEN SUBSTRING (password from 1 for 6) = 'PBKDF2' THEN split_part(password, '$', 4) END) AS salt FROM galaxy_user WHERE email='%U'"
 SQLDefaultGID                   %{env:GALAXY_GID}
 SQLDefaultUID                   %{env:GALAXY_UID}
-SQLPasswordPBKDF2               SHA256 10000 24
+SQLPasswordPBKDF2               SHA256 100000 24
 SQLPasswordUserSalt             sql:/GetUserSalt
 
 {% endif %}

--- a/templates/supervisor.conf.j2
+++ b/templates/supervisor.conf.j2
@@ -202,7 +202,7 @@ command         = {{ galaxy_server_dir }}/lib/galaxy/web/proxy/js/lib/main.js --
 autostart       = {{ supervisor_ie_proxy_autostart }}
 autorestart     = unexpected
 user            = {{ galaxy_user_name }}
-environment     = PATH={{ galaxy_venv_dir }}/bin
+environment     = PATH={{ galaxy_venv_dir }}/bin:%(ENV_PATH)s
 startsecs       = 5
 redirect_stderr = true
 {% endif %}

--- a/templates/supervisor.conf.j2
+++ b/templates/supervisor.conf.j2
@@ -202,6 +202,7 @@ command         = {{ galaxy_server_dir }}/lib/galaxy/web/proxy/js/lib/main.js --
 autostart       = {{ supervisor_ie_proxy_autostart }}
 autorestart     = unexpected
 user            = {{ galaxy_user_name }}
+environment     = PATH={{ galaxy_venv_dir }}/bin
 startsecs       = 5
 redirect_stderr = true
 {% endif %}


### PR DESCRIPTION
- Fix the supervisor.conf.j2 template, allowing nodejs to be found and started by supervisor
- Fix the proftpd.conf.j2, allowing proftpd to accommodate the current Galaxy password encoding
- connects with the new brand galaxykickstart (py3.7) for travis ci testing (this travis vm now turns green)
- my opinion in that docker testing could be suspended until it is fixed, but it is a question of taste (I prefer the green to the red) and not a call for that pr.

Feedbacks and improvements welcome before merging !